### PR TITLE
feat(container-logs): plugin core — parsers, Slack commands, Claude tools

### DIFF
--- a/plugins.local/container-logs.test.ts
+++ b/plugins.local/container-logs.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for container-logs plugin
+ *
+ * Covers: log line parsing (ANSI stripping, timestamp parsing),
+ * text filter/search over log lines, context extraction for search matches.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  stripAnsi,
+  parseLogLines,
+  filterLogLines,
+  searchLogLines,
+} from './container-logs.js';
+
+// =============================================================================
+// stripAnsi
+// =============================================================================
+
+describe('stripAnsi', () => {
+  it('strips basic colour codes', () => {
+    expect(stripAnsi('\x1b[32mhello\x1b[0m')).toBe('hello');
+  });
+
+  it('strips bold and reset codes', () => {
+    expect(stripAnsi('\x1b[1mBold\x1b[0m text')).toBe('Bold text');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(stripAnsi('plain text')).toBe('plain text');
+  });
+
+  it('handles empty string', () => {
+    expect(stripAnsi('')).toBe('');
+  });
+
+  it('strips multi-param codes', () => {
+    expect(stripAnsi('\x1b[38;5;200mcolour\x1b[0m')).toBe('colour');
+  });
+});
+
+// =============================================================================
+// parseLogLines
+// =============================================================================
+
+describe('parseLogLines', () => {
+  it('parses lines with docker --timestamps prefix', () => {
+    const raw = '2024-01-15T10:30:00.123456789Z This is the message';
+    const lines = parseLogLines(raw);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.timestamp).toBeInstanceOf(Date);
+    expect(lines[0]!.timestamp.getFullYear()).toBe(2024);
+    expect(lines[0]!.message).toBe('This is the message');
+  });
+
+  it('parses multiple lines', () => {
+    const raw = [
+      '2024-01-15T10:30:00.000Z Line one',
+      '2024-01-15T10:30:01.000Z Line two',
+    ].join('\n');
+    const lines = parseLogLines(raw);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]!.message).toBe('Line one');
+    expect(lines[1]!.message).toBe('Line two');
+  });
+
+  it('parses lines without timestamp prefix', () => {
+    const raw = 'plain log line without timestamp';
+    const lines = parseLogLines(raw);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.message).toBe('plain log line without timestamp');
+  });
+
+  it('strips ANSI codes from message', () => {
+    const raw = '2024-01-15T10:30:00.000Z \x1b[32mGreen message\x1b[0m';
+    const lines = parseLogLines(raw);
+    expect(lines[0]!.message).toBe('Green message');
+  });
+
+  it('skips blank lines', () => {
+    const raw = '2024-01-15T10:30:00.000Z Line one\n\n2024-01-15T10:30:01.000Z Line two\n';
+    const lines = parseLogLines(raw);
+    expect(lines).toHaveLength(2);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseLogLines('')).toEqual([]);
+  });
+});
+
+// =============================================================================
+// filterLogLines
+// =============================================================================
+
+describe('filterLogLines', () => {
+  const lines = [
+    { message: 'Server started on port 3000', timestamp: new Date() },
+    { message: 'GET /health 200 OK', timestamp: new Date() },
+    { message: 'ERROR: database connection failed', timestamp: new Date() },
+    { message: 'GET /api/users 200 OK', timestamp: new Date() },
+  ];
+
+  it('returns all lines when filter is empty', () => {
+    expect(filterLogLines(lines, '')).toHaveLength(4);
+  });
+
+  it('filters case-insensitively', () => {
+    expect(filterLogLines(lines, 'error')).toHaveLength(1);
+    expect(filterLogLines(lines, 'ERROR')).toHaveLength(1);
+    expect(filterLogLines(lines, 'Error')).toHaveLength(1);
+  });
+
+  it('returns only matching lines', () => {
+    const result = filterLogLines(lines, 'GET');
+    expect(result).toHaveLength(2);
+    expect(result.every((l) => l.message.includes('GET'))).toBe(true);
+  });
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterLogLines(lines, 'xyz-no-match')).toHaveLength(0);
+  });
+
+  it('handles empty lines array', () => {
+    expect(filterLogLines([], 'anything')).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// searchLogLines
+// =============================================================================
+
+describe('searchLogLines', () => {
+  const lines = Array.from({ length: 20 }, (_, i) => ({
+    message: i === 10 ? 'ERROR: disk full' : `Normal log line ${String(i)}`,
+    timestamp: new Date(),
+  }));
+
+  it('returns matching lines with context', () => {
+    const results = searchLogLines(lines, 'ERROR', 2);
+    expect(results.length).toBeGreaterThan(0);
+    const match = results.find((r) => r.message.includes('ERROR'));
+    expect(match).toBeDefined();
+  });
+
+  it('includes context lines around matches', () => {
+    const results = searchLogLines(lines, 'ERROR', 2);
+    // Should include lines 8-12 (2 before + match + 2 after)
+    expect(results.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('returns empty array when no matches', () => {
+    expect(searchLogLines(lines, 'xyz-no-match', 2)).toHaveLength(0);
+  });
+
+  it('deduplicates overlapping context windows', () => {
+    // Two close matches should not duplicate shared context lines
+    const twoMatches = [
+      ...lines.slice(0, 5),
+      { message: 'MATCH A', timestamp: new Date() },
+      { message: 'MATCH B', timestamp: new Date() },
+      ...lines.slice(7),
+    ];
+    const results = searchLogLines(twoMatches, 'MATCH', 2);
+    const msgs = results.map((r) => r.message);
+    // No duplicate messages
+    expect(new Set(msgs).size).toBe(msgs.length);
+  });
+
+  it('handles empty lines array', () => {
+    expect(searchLogLines([], 'ERROR', 2)).toHaveLength(0);
+  });
+});

--- a/plugins.local/container-logs.ts
+++ b/plugins.local/container-logs.ts
@@ -13,6 +13,7 @@
 import type { Plugin } from '../src/plugins/index.js';
 import type { ToolDefinition, ToolConfig } from '../src/services/tools/types.js';
 import { executeCommand } from '../src/utils/shell.js';
+import { getContainerStatus } from '../src/executors/docker.js';
 import { sanitizeServiceName } from '../src/utils/sanitize.js';
 import { scrubSensitiveData, processLogsForSlack, countPotentialSecrets } from '../src/formatters/scrub.js';
 import { logger } from '../src/utils/logger.js';
@@ -117,8 +118,11 @@ async function fetchContainerLogs(containerName: string, lines: number): Promise
     containerName,
   ]);
 
-  if (result.exitCode !== 0 && !result.stdout && !result.stderr) {
-    throw new Error(`Failed to get logs for ${containerName}`);
+  if (result.exitCode !== 0) {
+    const msg = (result.stderr || result.stdout).trim();
+    throw new Error(
+      msg.toLowerCase().includes('no such') ? `Container not found: ${containerName}` : `docker logs failed: ${msg}`
+    );
   }
 
   // docker writes container stderr to process stderr — combine both
@@ -126,19 +130,8 @@ async function fetchContainerLogs(containerName: string, lines: number): Promise
 }
 
 async function listRunningContainers(): Promise<string[]> {
-  const result = await executeCommand('docker', [
-    'ps',
-    '--format',
-    '{{.Names}}',
-  ]);
-
-  if (result.exitCode !== 0) return [];
-
-  return result.stdout
-    .trim()
-    .split('\n')
-    .map((n) => n.trim())
-    .filter(Boolean);
+  const containers = await getContainerStatus();
+  return containers.filter((c) => c.state === 'running').map((c) => c.name);
 }
 
 // =============================================================================
@@ -278,8 +271,9 @@ const containerLogsPlugin: Plugin = {
           const tailUrl = baseUrl
             ? `${baseUrl}/p/container-logs/tail?container=${encodeURIComponent(serviceName)}`
             : '(set WEB_BASE_URL in .env to enable direct links)';
+          const safeDisplay = serviceName.replace(/[*_`~]/g, '\\$&');
           await respond({
-            text: `Live tail for *${serviceName}*:\n${tailUrl}`,
+            text: `Live tail for *${safeDisplay}*:\n${tailUrl}`,
             response_type: 'ephemeral',
           });
           return;
@@ -321,7 +315,8 @@ const containerLogsPlugin: Plugin = {
         // Default: fetch logs for the named container
         // sub is the container name; parts[1] is the optional line count
         const containerName = sub;
-        const lineCount = Math.min(parseInt(parts[1] ?? String(DEFAULT_LINES), 10) || DEFAULT_LINES, MAX_LINES);
+        const rawN = parseInt(parts[1] ?? String(DEFAULT_LINES), 10);
+        const lineCount = Math.min(Math.max(1, isNaN(rawN) ? DEFAULT_LINES : rawN), MAX_LINES);
 
         let sanitized: string;
         try { sanitized = sanitizeServiceName(containerName); } catch {

--- a/plugins.local/container-logs.ts
+++ b/plugins.local/container-logs.ts
@@ -1,0 +1,355 @@
+/**
+ * Container Logs Plugin
+ *
+ * Read-only web log viewer for any Docker container, with Slack command
+ * shortcuts and Claude tool integration. Coexists with the built-in
+ * /logs command; web dashboard and SSE live tail added in PR 2b.
+ *
+ * Commands: /container-logs <service> [n] | tail <service> | search <service> <term> | help
+ * Web: /p/container-logs/ (PR 2b)
+ * Tools: container_logs:get_logs | search_logs | list_containers
+ */
+
+import type { Plugin } from '../src/plugins/index.js';
+import type { ToolDefinition, ToolConfig } from '../src/services/tools/types.js';
+import { executeCommand } from '../src/utils/shell.js';
+import { sanitizeServiceName } from '../src/utils/sanitize.js';
+import { scrubSensitiveData, processLogsForSlack, countPotentialSecrets } from '../src/formatters/scrub.js';
+import { logger } from '../src/utils/logger.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface LogLine {
+  timestamp: Date;
+  message: string;
+}
+
+// =============================================================================
+// Pure functions (exported for tests)
+// =============================================================================
+
+/** Strip ANSI escape codes from a string */
+export function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*[mGKHF]/g, '');
+}
+
+const DOCKER_TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+(.*)/;
+
+/**
+ * Parse raw docker logs output into structured log lines.
+ * Strips ANSI codes and handles optional docker --timestamps prefix.
+ */
+export function parseLogLines(raw: string): LogLine[] {
+  if (!raw.trim()) return [];
+
+  const lines: LogLine[] = [];
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const m = DOCKER_TIMESTAMP_RE.exec(trimmed);
+    if (m) {
+      lines.push({
+        timestamp: new Date(m[1] ?? ''),
+        message: stripAnsi((m[2] ?? '').trimStart()),
+      });
+    } else {
+      lines.push({
+        timestamp: new Date(0),
+        message: stripAnsi(trimmed),
+      });
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Filter log lines to those whose message contains the search term (case-insensitive).
+ * Empty term returns all lines.
+ */
+export function filterLogLines(lines: LogLine[], term: string): LogLine[] {
+  if (!term) return lines;
+  const lower = term.toLowerCase();
+  return lines.filter((l) => l.message.toLowerCase().includes(lower));
+}
+
+/**
+ * Search log lines for a term and return matching lines plus N lines of context.
+ * Overlapping context windows are deduplicated.
+ */
+export function searchLogLines(lines: LogLine[], term: string, context = 2): LogLine[] {
+  if (!term || lines.length === 0) return [];
+
+  const lower = term.toLowerCase();
+  const included = new Set<number>();
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]!.message.toLowerCase().includes(lower)) {
+      for (let j = Math.max(0, i - context); j <= Math.min(lines.length - 1, i + context); j++) {
+        included.add(j);
+      }
+    }
+  }
+
+  return Array.from(included)
+    .sort((a, b) => a - b)
+    .map((i) => lines[i]!);
+}
+
+// =============================================================================
+// Data fetchers
+// =============================================================================
+
+const DEFAULT_LINES = 50;
+const MAX_LINES = 500;
+
+async function fetchContainerLogs(containerName: string, lines: number): Promise<string> {
+  const result = await executeCommand('docker', [
+    'logs',
+    '--tail',
+    String(lines),
+    '--timestamps',
+    containerName,
+  ]);
+
+  if (result.exitCode !== 0 && !result.stdout && !result.stderr) {
+    throw new Error(`Failed to get logs for ${containerName}`);
+  }
+
+  // docker writes container stderr to process stderr — combine both
+  return result.stdout + result.stderr;
+}
+
+async function listRunningContainers(): Promise<string[]> {
+  const result = await executeCommand('docker', [
+    'ps',
+    '--format',
+    '{{.Names}}',
+  ]);
+
+  if (result.exitCode !== 0) return [];
+
+  return result.stdout
+    .trim()
+    .split('\n')
+    .map((n) => n.trim())
+    .filter(Boolean);
+}
+
+// =============================================================================
+// Claude AI tools
+// =============================================================================
+
+const tools: ToolDefinition[] = [
+  {
+    spec: {
+      name: 'list_containers',
+      description: 'List all currently running Docker containers by name.',
+      input_schema: { type: 'object', properties: {} },
+    },
+    execute: async (_input: Record<string, unknown>, _config: ToolConfig) => {
+      try {
+        const names = await listRunningContainers();
+        if (names.length === 0) return 'No running containers found.';
+        return `Running containers (${String(names.length)}):\n${names.map((n) => `• ${n}`).join('\n')}`;
+      } catch (err) {
+        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  },
+  {
+    spec: {
+      name: 'get_logs',
+      description: 'Fetch recent log lines for a named container. Output is scrubbed for secrets.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          container: { type: 'string', description: 'Container name' },
+          lines: { type: 'number', description: 'Number of lines to fetch (default 50, max 200)' },
+        },
+        required: ['container'],
+      },
+    },
+    execute: async (input: Record<string, unknown>, _config: ToolConfig) => {
+      try {
+        const rawContainer = String(input.container ?? '').trim();
+        if (!rawContainer) return 'Error: container name is required';
+        if (rawContainer.startsWith('-') || rawContainer.length > 255) return 'Error: invalid container name';
+
+        const n = Math.min(Number(input.lines ?? DEFAULT_LINES), 200);
+        const raw = await fetchContainerLogs(rawContainer, n);
+        const scrubbed = scrubSensitiveData(raw);
+        const lines = parseLogLines(scrubbed);
+        if (lines.length === 0) return `No log output from ${rawContainer}`;
+        return `Logs: ${rawContainer} (last ${String(lines.length)} lines)\n${lines.map((l) => l.message).join('\n')}`;
+      } catch (err) {
+        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  },
+  {
+    spec: {
+      name: 'search_logs',
+      description: 'Search recent logs of a container for a pattern. Returns matching lines with 2 lines of context. Output is scrubbed for secrets.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          container: { type: 'string', description: 'Container name' },
+          term: { type: 'string', description: 'Search term (case-insensitive)' },
+          lines: { type: 'number', description: 'Lines to search (default 500, max 1000)' },
+        },
+        required: ['container', 'term'],
+      },
+    },
+    execute: async (input: Record<string, unknown>, _config: ToolConfig) => {
+      try {
+        const rawContainer = String(input.container ?? '').trim();
+        if (!rawContainer) return 'Error: container name is required';
+        if (rawContainer.startsWith('-') || rawContainer.length > 255) return 'Error: invalid container name';
+
+        const term = String(input.term ?? '').trim();
+        if (!term) return 'Error: search term is required';
+
+        const n = Math.min(Number(input.lines ?? 500), 1000);
+        const raw = await fetchContainerLogs(rawContainer, n);
+        const scrubbed = scrubSensitiveData(raw);
+        const all = parseLogLines(scrubbed);
+        const results = searchLogLines(all, term);
+
+        if (results.length === 0) return `No matches for "${term}" in ${rawContainer} logs.`;
+        return `Found ${String(results.length)} lines matching "${term}" in ${rawContainer}:\n${results.map((l) => l.message).join('\n')}`;
+      } catch (err) {
+        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  },
+];
+
+// =============================================================================
+// Plugin export
+// =============================================================================
+
+const containerLogsPlugin: Plugin = {
+  name: 'container-logs',
+  version: '1.0.0',
+  description: 'Web log viewer for Docker containers with live tail and search',
+
+  helpEntries: [
+    { command: '/container-logs <service> [n]', description: 'Post last N lines (default 50)', group: 'Container Logs' },
+    { command: '/container-logs tail <service>', description: 'Post link to live tail view', group: 'Container Logs' },
+    { command: '/container-logs search <service> <term>', description: 'Search logs for term', group: 'Container Logs' },
+    { command: '/container-logs help', description: 'Command reference', group: 'Container Logs' },
+  ],
+
+  registerCommands(app) {
+    app.command('/container-logs', async ({ command, ack, respond }) => {
+      await ack();
+
+      const parts = (command.text ?? '').trim().split(/\s+/);
+      const sub = parts[0]?.toLowerCase() ?? '';
+
+      try {
+        if (!sub || sub === 'help') {
+          await respond({
+            text: [
+              '*Container Logs*',
+              '`/container-logs <service> [n]` — last N lines (default 50, max 500)',
+              '`/container-logs tail <service>` — link to live tail view',
+              '`/container-logs search <service> <term>` — search recent logs',
+              '`/container-logs help` — this message',
+            ].join('\n'),
+            response_type: 'ephemeral',
+          });
+          return;
+        }
+
+        if (sub === 'tail') {
+          const serviceName = parts[1] ?? '';
+          if (!serviceName) {
+            await respond({ text: 'Usage: `/container-logs tail <service>`', response_type: 'ephemeral' });
+            return;
+          }
+          const baseUrl = process.env['WEB_BASE_URL'] ?? '';
+          const tailUrl = baseUrl
+            ? `${baseUrl}/p/container-logs/tail?container=${encodeURIComponent(serviceName)}`
+            : '(set WEB_BASE_URL in .env to enable direct links)';
+          await respond({
+            text: `Live tail for *${serviceName}*:\n${tailUrl}`,
+            response_type: 'ephemeral',
+          });
+          return;
+        }
+
+        if (sub === 'search') {
+          const serviceName = parts[1] ?? '';
+          const term = parts.slice(2).join(' ');
+          if (!serviceName || !term) {
+            await respond({ text: 'Usage: `/container-logs search <service> <term>`', response_type: 'ephemeral' });
+            return;
+          }
+
+          let sanitized: string;
+          try { sanitized = sanitizeServiceName(serviceName); } catch {
+            await respond({ text: 'Error: invalid container name', response_type: 'ephemeral' });
+            return;
+          }
+
+          const raw = await fetchContainerLogs(sanitized, MAX_LINES);
+          const scrubbed = scrubSensitiveData(raw);
+          const all = parseLogLines(scrubbed);
+          const results = searchLogLines(all, term);
+
+          if (results.length === 0) {
+            await respond({ text: `No matches for \`${term}\` in *${sanitized}* logs.`, response_type: 'ephemeral' });
+            return;
+          }
+
+          const text = results.map((l) => l.message).join('\n');
+          const truncated = text.length > 2800 ? text.slice(0, 2800) + '\n…(truncated)' : text;
+          await respond({
+            text: `*${sanitized}* — matches for \`${term}\`:\n\`\`\`${truncated}\`\`\``,
+            response_type: 'ephemeral',
+          });
+          return;
+        }
+
+        // Default: fetch logs for the named container
+        // sub is the container name; parts[1] is the optional line count
+        const containerName = sub;
+        const lineCount = Math.min(parseInt(parts[1] ?? String(DEFAULT_LINES), 10) || DEFAULT_LINES, MAX_LINES);
+
+        let sanitized: string;
+        try { sanitized = sanitizeServiceName(containerName); } catch {
+          await respond({ text: 'Error: invalid container name', response_type: 'ephemeral' });
+          return;
+        }
+
+        const raw = await fetchContainerLogs(sanitized, lineCount);
+        const processed = processLogsForSlack(raw);
+        const secretCount = countPotentialSecrets(raw);
+
+        const warning = '⚠️ Logs may contain sensitive info. Scrubbing applied but not foolproof.';
+        const secretNote = secretCount > 0 ? `\n🔒 ${String(secretCount)} potential secret(s) redacted.` : '';
+        const header = `*Logs: ${sanitized}* (last ${String(lineCount)} lines)${secretNote}`;
+
+        await respond({
+          text: `${warning}\n${header}\n\`\`\`${processed || '(no output)'}\`\`\``,
+          response_type: 'ephemeral',
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unexpected error';
+        logger.error('container-logs command failed', { error: message, text: command.text });
+        await respond({ text: `❌ Error: ${message}`, response_type: 'ephemeral' });
+      }
+    });
+  },
+
+  tools,
+};
+
+export default containerLogsPlugin;


### PR DESCRIPTION
## Summary

PR 2a of ticket #2 — core of the \`container-logs\` plugin. General-purpose container log viewer with Slack commands and Claude tools. Coexists with the built-in \`/logs\` command. Web dashboard + SSE live tail follow in PR 2b.

## Changes

- \`plugins.local/container-logs.ts\` — plugin with:
  - \`stripAnsi\`, \`parseLogLines\`, \`filterLogLines\`, \`searchLogLines\` — pure parsing functions (all exported for testability)
  - \`/container-logs <service> [n] | tail <service> | search <service> <term> | help\` Slack command with scrubbing + secret-count warnings
  - Three Claude tools: \`container_logs:list_containers\`, \`get_logs\`, \`search_logs\`
- \`plugins.local/container-logs.test.ts\` — 21 unit tests for all pure parser functions

## Code review fixes

- \`fetchContainerLogs\` throws on **any** non-zero exitCode — docker errors no longer appear as fake log lines
- \`listRunningContainers\` refactored to use \`getContainerStatus()\` from \`src/executors/docker.ts\`
- \`lineCount\` clamped to \`>= 1\` — blocks negative values reaching \`docker logs --tail\`
- Slack mrkdwn special chars escaped in \`tail\` display name

## Test plan

- [x] 21 parser unit tests, 3261/3261 total pass
- [x] TypeScript strict — no errors; lint passes
- [x] Code review — all critical/significant findings addressed

## Deferred to PR 2b

- Web dashboard at \`/p/container-logs/\`
- SSE live tail page

Closes #2 (partial)