### PR TITLE
feat(container-logs): web dashboard and SSE live tail

### DIFF
--- a/plugins.local/container-logs.ts
+++ b/plugins.local/container-logs.ts
@@ -147,7 +147,11 @@ const CLIENT_FILTER_JS = `
 
 async function buildDashboardHtml(req: { query: Record<string, string> }): Promise<string> {
   const containers = await listRunningContainers();
-  const selectedContainer = req.query['container'] ?? '';
+  const rawContainer = req.query['container'] ?? '';
+  // Block flag-injection; dots allowed for Swarm task names (myapp.1)
+  const selectedContainer = (!rawContainer || rawContainer.startsWith('-') || rawContainer.length > 255)
+    ? ''
+    : rawContainer;
   const lineCount = Math.min(Math.max(1, parseInt(req.query['lines'] ?? '100', 10) || 100), 500);
 
   const containerOptions = containers
@@ -216,10 +220,13 @@ let tailContainer = '';
 let tailLastTs = '';
 
 function startTailPolling(container: string, ctx: PluginContext): void {
+  // Always stop and restart — ensures container switch takes effect immediately
+  if (tailPollTimer) {
+    clearInterval(tailPollTimer);
+    tailPollTimer = null;
+  }
   tailContainer = container;
   tailLastTs = '';
-
-  if (tailPollTimer) return;
 
   tailPollTimer = setInterval(async () => {
     if (ctx.sse.clientCount() === 0) {
@@ -277,7 +284,8 @@ function registerContainerLogsWebRoutes(router: PluginRouter): void {
   });
 
   router.get('/tail', (req, res, ctx) => {
-    const container = (req.query as Record<string, string>)['container'] ?? '';
+    const rawContainer = (req.query as Record<string, string>)['container'] ?? '';
+    const container = (!rawContainer || rawContainer.startsWith('-') || rawContainer.length > 255) ? '' : rawContainer;
     if (!container) { res.redirect('/p/container-logs/'); return; }
 
     startTailPolling(container, ctx);

--- a/plugins.local/container-logs.ts
+++ b/plugins.local/container-logs.ts
@@ -10,7 +10,10 @@
  * Tools: container_logs:get_logs | search_logs | list_containers
  */
 
-import type { Plugin } from '../src/plugins/index.js';
+import type { Plugin, DashboardWidget } from '../src/plugins/index.js';
+import type { PluginRouter } from '../src/plugins/index.js';
+import type { PluginContext } from '../src/plugins/types.js';
+import { renderPluginPage, pluginTable, escapeHtml } from '../src/plugins/index.js';
 import type { ToolDefinition, ToolConfig } from '../src/services/tools/types.js';
 import { executeCommand } from '../src/utils/shell.js';
 import { getContainerStatus } from '../src/executors/docker.js';
@@ -100,6 +103,220 @@ export function searchLogLines(lines: LogLine[], term: string, context = 2): Log
   return Array.from(included)
     .sort((a, b) => a - b)
     .map((i) => lines[i]!);
+}
+
+// =============================================================================
+// Web dashboard
+// =============================================================================
+
+const WEB_CSS = `
+  .cl-toolbar { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; margin-bottom:1rem; }
+  .cl-select, .cl-input, .cl-btn { padding:.35rem .7rem; border-radius:6px; font-size:.875rem; border:1px solid var(--border); background:var(--card-bg); color:var(--text); }
+  .cl-select { cursor:pointer; }
+  .cl-btn { cursor:pointer; font-weight:600; background:var(--accent,#2f81f7); color:#fff; border-color:transparent; }
+  .cl-btn:hover { opacity:.9; }
+  .cl-btn.secondary { background:var(--card-bg); color:var(--text); border-color:var(--border); }
+  .cl-log-area { background:var(--code-bg,#0d1117); border:1px solid var(--border); border-radius:6px; padding:.75rem 1rem; font-family:var(--font-mono,monospace); font-size:.78rem; line-height:1.55; overflow-x:auto; max-height:70vh; overflow-y:auto; white-space:pre-wrap; word-break:break-all; }
+  .cl-log-line { display:block; }
+  .cl-log-line.hidden { display:none; }
+  .cl-log-line .ts { color:var(--text-muted); margin-right:.4rem; }
+  .cl-empty { color:var(--text-muted); font-style:italic; padding:.5rem 0; }
+  .cl-warn { color:var(--warning,#e6a817); font-size:.8rem; margin-bottom:.75rem; }
+  .cl-status { font-size:.78rem; color:var(--text-muted); margin-top:.5rem; text-align:right; }
+  .cl-tail-header { display:flex; align-items:center; gap:.75rem; margin-bottom:1rem; flex-wrap:wrap; }
+  .cl-tail-header h2 { margin:0; font-size:1.05rem; }
+  .cl-dot { width:8px; height:8px; border-radius:50%; background:#3fb950; display:inline-block; animation:cl-blink 1.2s ease-in-out infinite; }
+  @keyframes cl-blink { 0%,100%{opacity:1} 50%{opacity:.25} }
+`;
+
+const CLIENT_FILTER_JS = `
+  function applyFilter() {
+    const term = document.getElementById('cl-filter')?.value?.toLowerCase() ?? '';
+    document.querySelectorAll('.cl-log-line').forEach(el => {
+      el.classList.toggle('hidden', term !== '' && !el.textContent?.toLowerCase().includes(term));
+    });
+    const vis = document.querySelectorAll('.cl-log-line:not(.hidden)').length;
+    const status = document.getElementById('cl-status');
+    if (status) status.textContent = term ? vis + ' matching lines' : '';
+  }
+  document.getElementById('cl-filter')?.addEventListener('input', applyFilter);
+  document.getElementById('cl-ts-toggle')?.addEventListener('change', e => {
+    document.querySelectorAll('.ts').forEach(el => el.style.display = e.target.checked ? '' : 'none');
+  });
+`;
+
+async function buildDashboardHtml(req: { query: Record<string, string> }): Promise<string> {
+  const containers = await listRunningContainers();
+  const selectedContainer = req.query['container'] ?? '';
+  const lineCount = Math.min(Math.max(1, parseInt(req.query['lines'] ?? '100', 10) || 100), 500);
+
+  const containerOptions = containers
+    .map((c) => `<option value="${escapeHtml(c)}"${c === selectedContainer ? ' selected' : ''}>${escapeHtml(c)}</option>`)
+    .join('');
+  const noneOption = containers.length === 0 ? '<option value="">No running containers</option>' : '<option value="">— pick a container —</option>';
+
+  const toolbar = `<form method="get" action="/p/container-logs/" class="cl-toolbar">
+    <select name="container" class="cl-select">${noneOption}${containerOptions}</select>
+    <select name="lines" class="cl-select">
+      ${[50, 100, 500].map((n) => `<option value="${String(n)}"${n === lineCount ? ' selected' : ''}>${String(n)} lines</option>`).join('')}
+    </select>
+    <button type="submit" class="cl-btn">Load logs</button>
+    ${selectedContainer ? `<a href="/p/container-logs/tail?container=${encodeURIComponent(selectedContainer)}" class="cl-btn secondary">Live tail ›</a>` : ''}
+    <input id="cl-filter" placeholder="Filter lines…" class="cl-input" style="flex:1;min-width:140px">
+    <label style="display:flex;gap:.3rem;align-items:center;font-size:.85rem"><input type="checkbox" id="cl-ts-toggle" checked> timestamps</label>
+  </form>`;
+
+  let logHtml = '';
+  let warnHtml = '';
+  if (selectedContainer) {
+    try {
+      const raw = await fetchContainerLogs(selectedContainer, lineCount);
+      const secretCount = countPotentialSecrets(raw);
+      if (secretCount > 0) {
+        warnHtml = `<p class="cl-warn">🔒 ${String(secretCount)} potential secret(s) redacted. Review carefully.</p>`;
+      }
+      const scrubbed = scrubSensitiveData(raw);
+      const lines = parseLogLines(scrubbed);
+      if (lines.length === 0) {
+        logHtml = '<div class="cl-log-area"><span class="cl-empty">(no output)</span></div>';
+      } else {
+        const lineHtml = lines.map((l) => {
+          const ts = l.timestamp.getTime() > 0 ? `<span class="ts">${escapeHtml(l.timestamp.toISOString().replace('T', ' ').slice(0, 23))}</span>` : '';
+          return `<span class="cl-log-line">${ts}${escapeHtml(l.message)}</span>`;
+        }).join('\n');
+        logHtml = `<div class="cl-log-area" id="cl-log">${lineHtml}</div><div class="cl-status" id="cl-status"></div>`;
+      }
+    } catch (err) {
+      logHtml = `<p class="cl-empty">Error: ${escapeHtml(err instanceof Error ? err.message : String(err))}</p>`;
+    }
+  } else {
+    logHtml = '<p class="cl-empty">Select a container above to view its logs.</p>';
+  }
+
+  return `${toolbar}${warnHtml}${logHtml}`;
+}
+
+function buildTailHtml(container: string): string {
+  const safeContainer = escapeHtml(container);
+  return `<div class="cl-tail-header">
+    <span class="cl-dot" id="cl-dot"></span>
+    <h2>Live tail: <code>${safeContainer}</code></h2>
+    <button class="cl-btn secondary" id="cl-stop" onclick="toggleTail()">Pause</button>
+    <a href="/p/container-logs/?container=${encodeURIComponent(container)}" class="cl-btn secondary">← Logs</a>
+    <input id="cl-filter" placeholder="Filter lines…" class="cl-input" style="flex:1;min-width:140px">
+    <label style="display:flex;gap:.3rem;align-items:center;font-size:.85rem"><input type="checkbox" id="cl-ts-toggle" checked> timestamps</label>
+  </div>
+  <div class="cl-log-area" id="cl-log" style="max-height:80vh"></div>
+  <div class="cl-status" id="cl-status">Connecting…</div>`;
+}
+
+// SSE tail state — single shared stream (home server single-user model)
+let tailPollTimer: ReturnType<typeof setInterval> | null = null;
+let tailContainer = '';
+let tailLastTs = '';
+
+function startTailPolling(container: string, ctx: PluginContext): void {
+  tailContainer = container;
+  tailLastTs = '';
+
+  if (tailPollTimer) return;
+
+  tailPollTimer = setInterval(async () => {
+    if (ctx.sse.clientCount() === 0) {
+      stopTailPolling();
+      return;
+    }
+
+    try {
+      const args = ['logs', '--timestamps', tailContainer];
+      if (tailLastTs) {
+        args.push('--since', tailLastTs);
+      } else {
+        args.push('--tail', '50');
+      }
+
+      const result = await executeCommand('docker', args, { timeout: 5000 });
+      if (result.exitCode !== 0) return;
+
+      const raw = result.stdout + result.stderr;
+      const lines = parseLogLines(scrubSensitiveData(raw));
+
+      if (lines.length > 0) {
+        const last = lines[lines.length - 1]!;
+        if (last.timestamp.getTime() > 0) {
+          tailLastTs = last.timestamp.toISOString();
+        }
+        ctx.sse.broadcast('log-lines', lines.map((l) => ({ ts: l.timestamp.toISOString(), msg: l.message })));
+      }
+    } catch {
+      // poll errors are transient; keep trying
+    }
+  }, 2000);
+}
+
+function stopTailPolling(): void {
+  if (tailPollTimer) {
+    clearInterval(tailPollTimer);
+    tailPollTimer = null;
+  }
+  tailContainer = '';
+  tailLastTs = '';
+}
+
+function registerContainerLogsWebRoutes(router: PluginRouter): void {
+  router.get('/', async (req, res) => {
+    try {
+      const query = req.query as Record<string, string>;
+      const body = await buildDashboardHtml({ query });
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.send(renderPluginPage({ title: 'Container Logs', pluginName: 'container-logs', body, styles: WEB_CSS, scripts: `<script>${CLIENT_FILTER_JS}</script>`, unreadCount: 0 }));
+    } catch (err) {
+      logger.error('container-logs dashboard error', { error: err instanceof Error ? err.message : String(err) });
+      res.status(500).send('Error loading dashboard');
+    }
+  });
+
+  router.get('/tail', (req, res, ctx) => {
+    const container = (req.query as Record<string, string>)['container'] ?? '';
+    if (!container) { res.redirect('/p/container-logs/'); return; }
+
+    startTailPolling(container, ctx);
+
+    const tailJs = `<script>
+      const es = new EventSource('/p/container-logs/stream');
+      const log = document.getElementById('cl-log');
+      const status = document.getElementById('cl-status');
+      const dot = document.getElementById('cl-dot');
+      let running = true;
+      es.addEventListener('log-lines', e => {
+        const lines = JSON.parse(e.data);
+        lines.forEach(l => {
+          const span = document.createElement('span');
+          span.className = 'cl-log-line';
+          const tsEl = document.createElement('span');
+          tsEl.className = 'ts';
+          tsEl.textContent = l.ts.replace('T',' ').slice(0,23) + ' ';
+          if (!document.getElementById('cl-ts-toggle').checked) tsEl.style.display = 'none';
+          span.appendChild(tsEl);
+          span.appendChild(document.createTextNode(l.msg));
+          log.appendChild(span);
+          applyFilter();
+        });
+        log.scrollTop = log.scrollHeight;
+        if (status) status.textContent = log.querySelectorAll('.cl-log-line').length + ' lines';
+      });
+      es.addEventListener('error', () => { if (status) status.textContent = 'Connection lost — reconnecting…'; });
+      function toggleTail() {
+        running = !running;
+        document.getElementById('cl-stop').textContent = running ? 'Pause' : 'Resume';
+        dot.style.animationPlayState = running ? 'running' : 'paused';
+      }
+      ${CLIENT_FILTER_JS}
+    </script>`;
+
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.send(renderPluginPage({ title: `Tail: ${container}`, pluginName: 'container-logs', body: buildTailHtml(container), styles: WEB_CSS, scripts: tailJs, unreadCount: 0 }));
+  });
 }
 
 // =============================================================================
@@ -345,6 +562,31 @@ const containerLogsPlugin: Plugin = {
   },
 
   tools,
+
+  webNavEntry: { label: 'Container Logs', icon: 'file-text' },
+
+  webPages: [
+    { name: 'Dashboard', path: '/' },
+    { name: 'Live Tail', path: '/tail' },
+  ],
+
+  registerWebRoutes: registerContainerLogsWebRoutes,
+
+  getWidgets(): DashboardWidget[] {
+    return [{
+      title: 'Container Logs',
+      icon: 'file-text',
+      html: '<span style="color:var(--text-muted);font-size:.85rem">View and search container logs</span>',
+      link: '/p/container-logs/',
+      priority: 80,
+      size: 'small',
+    }];
+  },
+
+  destroy(): Promise<void> {
+    stopTailPolling();
+    return Promise.resolve();
+  },
 };
 
 export default containerLogsPlugin;


### PR DESCRIPTION
## Summary

PR 2b of ticket #2 — completes the container-logs plugin with a web dashboard and SSE-powered live tail page.

## Changes

- `GET /p/container-logs/` — dashboard with container dropdown, line count selector (50/100/500), server-rendered log view with ANSI stripping and secret scrubbing, client-side text filter, timestamp toggle
- `GET /p/container-logs/tail?container=name` — live tail page; backend polls `docker logs --since` every 2 s and broadcasts new lines via SSE
- `getWidgets()` — dashboard widget linking to the log viewer
- `destroy()` — stops poll timer on plugin shutdown

## Code review fixes

- `startTailPolling` now stops-and-restarts the interval on container switch — prevents stale log lines from a previous container appearing to SSE clients
- `selectedContainer` (dashboard) and `container` (tail route) validated with flag-injection guard before reaching `docker logs`; dots allowed for Swarm task names (`myapp.1`)

## Test plan

- [x] 3261/3261 tests pass
- [x] TypeScript strict — no errors
- [x] Lint passes
- [x] Code review — all critical/significant findings addressed

Closes #2