### PR TITLE
test: improve branch coverage across templates, router, and tools

### DIFF
--- a/tests/services/tools/server-tools.test.ts
+++ b/tests/services/tools/server-tools.test.ts
@@ -527,6 +527,41 @@ describe('searchContainerLogsTool', () => {
       );
       expect(result).toContain('Error: search_pattern is required');
     });
+
+    it('returns no-matches message when stdout and stderr are empty', async () => {
+      (executeCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+        stdout: '', stderr: '', exitCode: 0,
+      });
+      const result = await searchContainerLogsTool.execute(
+        { container_name: 'nginx', search_pattern: 'ERROR' },
+        defaultConfig
+      );
+      expect(result).toContain('No logs found');
+    });
+
+    it('performs case-sensitive search when case_insensitive is false', async () => {
+      (executeCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+        stdout: 'Error: uppercase\nerror: lowercase',
+        stderr: '', exitCode: 0,
+      });
+      const result = await searchContainerLogsTool.execute(
+        { container_name: 'nginx', search_pattern: 'Error', case_insensitive: false },
+        defaultConfig
+      );
+      expect(result).toContain('Found 1 matches');
+      expect(result).toContain('Error: uppercase');
+      expect(result).not.toContain('error: lowercase');
+    });
+
+    it('returns error string when executeCommand throws', async () => {
+      (executeCommand as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('docker daemon not running'));
+      const result = await searchContainerLogsTool.execute(
+        { container_name: 'nginx', search_pattern: 'ERROR' },
+        defaultConfig
+      );
+      expect(result).toContain('Error searching logs:');
+      expect(result).toContain('docker daemon not running');
+    });
 });
 
 describe('dockerImagesTool', () => {
@@ -563,5 +598,21 @@ describe('dockerImagesTool', () => {
 
     const result = await dockerImagesTool.execute({}, defaultConfig);
     expect(result).toContain('No Docker images found');
+  });
+
+  it('returns error string when exitCode is non-zero', async () => {
+    (executeCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      stdout: '', stderr: 'permission denied', exitCode: 1,
+    });
+    const result = await dockerImagesTool.execute({}, defaultConfig);
+    expect(result).toContain('Error listing images:');
+    expect(result).toContain('permission denied');
+  });
+
+  it('returns error string when executeCommand throws', async () => {
+    (executeCommand as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('socket timeout'));
+    const result = await dockerImagesTool.execute({}, defaultConfig);
+    expect(result).toContain('Error listing Docker images:');
+    expect(result).toContain('socket timeout');
   });
 });

--- a/tests/web/notifications.test.ts
+++ b/tests/web/notifications.test.ts
@@ -318,4 +318,48 @@ describe('notification templates', () => {
       expect(html).toContain('notif-pref-push');
     });
   });
+
+  describe('time bucket section headers', () => {
+    const ONE_DAY_MS = 24 * 3600 * 1000;
+
+    function makeNotif(id: number, createdAt: number): Notification {
+      return { id, source: 'system', level: 'info', title: `Notif ${String(id)}`, body: null, link: null, createdAt, readAt: null };
+    }
+
+    it('renders Yesterday section for notifications 25 hours old', () => {
+      const notif = makeNotif(10, Date.now() - 25 * ONE_DAY_MS / 24);
+      const html = renderNotificationPage([notif], 1);
+      expect(html).toContain('data-bucket="yesterday"');
+      expect(html).toContain('Yesterday');
+    });
+
+    it('renders This Week section for notifications 4 days old', () => {
+      const notif = makeNotif(11, Date.now() - 4 * ONE_DAY_MS);
+      const html = renderNotificationPage([notif], 1);
+      expect(html).toContain('data-bucket="this-week"');
+      expect(html).toContain('This Week');
+    });
+
+    it('renders Older section for notifications 10 days old', () => {
+      const notif = makeNotif(12, Date.now() - 10 * ONE_DAY_MS);
+      const html = renderNotificationPage([notif], 1);
+      expect(html).toContain('data-bucket="older"');
+      expect(html).toContain('Older');
+    });
+
+    it('renders multiple bucket sections when notifications span days', () => {
+      const today = makeNotif(20, Date.now() - 5 * 60 * 1000);
+      const yesterday = makeNotif(21, Date.now() - 25 * ONE_DAY_MS / 24);
+      const html = renderNotificationPage([today, yesterday], 2);
+      expect(html).toContain('data-bucket="today"');
+      expect(html).toContain('data-bucket="yesterday"');
+    });
+
+    it('omits empty bucket sections', () => {
+      const notif = makeNotif(30, Date.now() - 4 * ONE_DAY_MS);
+      const html = renderNotificationPage([notif], 1);
+      expect(html).not.toContain('data-bucket="today"');
+      expect(html).not.toContain('data-bucket="older"');
+    });
+  });
 });

--- a/tests/web/plugin-router.test.ts
+++ b/tests/web/plugin-router.test.ts
@@ -4,7 +4,12 @@ vi.mock('../../src/utils/logger.js', () => ({
   logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('../../src/web/sse.js', () => ({
+  getSharedSSEManager: vi.fn(),
+}));
+
 import { createPluginRouter, getPluginExpressRouter, getPluginNavEntries, clearPluginRoutes, isPluginPublic } from '../../src/web/plugin-router.js';
+import { getSharedSSEManager } from '../../src/web/sse.js';
 import type { PluginContext } from '../../src/plugins/types.js';
 import type { Request, Response } from 'express';
 
@@ -185,6 +190,131 @@ describe('plugin router', () => {
 
       clearPluginRoutes();
       expect(getPluginNavEntries()).toEqual([]);
+    });
+  });
+
+  describe('SSE stream endpoint', () => {
+    type RouterLayer = { route?: { path: string; methods: Record<string, boolean>; stack: { handle: (req: Request, res: Response, next: () => void) => void }[] } };
+
+    function findRoute(path: string) {
+      const layers = (getPluginExpressRouter() as unknown as { stack: RouterLayer[] }).stack;
+      return layers.find((l) => l.route?.path === path);
+    }
+
+    function makeRes(headersSent = false) {
+      return {
+        headersSent,
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis(),
+      } as unknown as Response;
+    }
+
+    it('returns 503 when SSE manager is not available', () => {
+      vi.mocked(getSharedSSEManager).mockReturnValue(null);
+      createPluginRouter('sse-test', mockCtx);
+
+      const layer = findRoute('/sse-test/stream');
+      expect(layer).toBeDefined();
+
+      const mockRes = makeRes();
+      layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
+
+      expect(mockRes.status).toHaveBeenCalledWith(503);
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'SSE not available' });
+    });
+
+    it('calls addClient with the correct plugin channel ID when SSE is available', () => {
+      const mockManager = { addClient: vi.fn() };
+      vi.mocked(getSharedSSEManager).mockReturnValue(mockManager as never);
+      createPluginRouter('sse-test2', mockCtx);
+
+      const mockRes = makeRes();
+      const layer = findRoute('/sse-test2/stream');
+      layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
+
+      expect(mockManager.addClient).toHaveBeenCalledWith('plugin:sse-test2', mockRes);
+    });
+
+    it('sends 500 when addClient throws and headers are not yet sent', () => {
+      const mockManager = { addClient: vi.fn(() => { throw new Error('stream error'); }) };
+      vi.mocked(getSharedSSEManager).mockReturnValue(mockManager as never);
+      createPluginRouter('sse-test3', mockCtx);
+
+      const mockRes = makeRes(false);
+      const layer = findRoute('/sse-test3/stream');
+      layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith('SSE error');
+    });
+
+    it('does not call res.status when addClient throws but headers already sent', () => {
+      const mockManager = { addClient: vi.fn(() => { throw new Error('stream error'); }) };
+      vi.mocked(getSharedSSEManager).mockReturnValue(mockManager as never);
+      createPluginRouter('sse-test4', mockCtx);
+
+      const mockRes = makeRes(true);
+      const layer = findRoute('/sse-test4/stream');
+      layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
+
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('registers only one /stream route per plugin even when called twice', () => {
+      createPluginRouter('sse-dup', mockCtx);
+      createPluginRouter('sse-dup', mockCtx);
+
+      const layers = (getPluginExpressRouter() as unknown as { stack: RouterLayer[] }).stack;
+      const streamRoutes = layers.filter((l) => l.route?.path === '/sse-dup/stream');
+      expect(streamRoutes).toHaveLength(1);
+    });
+  });
+
+  describe('async handler error paths', () => {
+    type RouterLayer = { route?: { path: string; methods: Record<string, boolean>; stack: { handle: (req: Request, res: Response, next: () => void) => void }[] } };
+
+    function findRoute(path: string) {
+      const layers = (getPluginExpressRouter() as unknown as { stack: RouterLayer[] }).stack;
+      return layers.find((l) => l.route?.path === path);
+    }
+
+    it('sends 500 on async handler rejection when headers not sent', async () => {
+      const router = createPluginRouter('async-err', mockCtx);
+      router.get('/fail', async () => { throw new Error('async boom'); });
+
+      const mockRes = {
+        headersSent: false,
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      const layer = findRoute('/async-err/fail');
+      layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
+
+      // Let the Promise rejection propagate through the catch handler
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith('Internal plugin error');
+    });
+
+    it('does not call res.status on async rejection when headers already sent', async () => {
+      const router = createPluginRouter('async-err2', mockCtx);
+      router.get('/fail2', async () => { throw new Error('async boom'); });
+
+      const mockRes = {
+        headersSent: true,
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      const layer = findRoute('/async-err2/fail2');
+      layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockRes.status).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/web/plugin-router.test.ts
+++ b/tests/web/plugin-router.test.ts
@@ -194,7 +194,7 @@ describe('plugin router', () => {
   });
 
   describe('SSE stream endpoint', () => {
-    type RouterLayer = { route?: { path: string; methods: Record<string, boolean>; stack: { handle: (req: Request, res: Response, next: () => void) => void }[] } };
+    interface RouterLayer { route?: { path: string; methods: Record<string, boolean>; stack: { handle: (req: Request, res: Response, next: () => void) => void }[] } }
 
     function findRoute(path: string) {
       const layers = (getPluginExpressRouter() as unknown as { stack: RouterLayer[] }).stack;
@@ -218,6 +218,7 @@ describe('plugin router', () => {
       expect(layer).toBeDefined();
 
       const mockRes = makeRes();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
 
       expect(mockRes.status).toHaveBeenCalledWith(503);
@@ -231,6 +232,7 @@ describe('plugin router', () => {
 
       const mockRes = makeRes();
       const layer = findRoute('/sse-test2/stream');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
 
       expect(mockManager.addClient).toHaveBeenCalledWith('plugin:sse-test2', mockRes);
@@ -243,6 +245,7 @@ describe('plugin router', () => {
 
       const mockRes = makeRes(false);
       const layer = findRoute('/sse-test3/stream');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
@@ -256,6 +259,7 @@ describe('plugin router', () => {
 
       const mockRes = makeRes(true);
       const layer = findRoute('/sse-test4/stream');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
 
       expect(mockRes.status).not.toHaveBeenCalled();
@@ -272,7 +276,7 @@ describe('plugin router', () => {
   });
 
   describe('async handler error paths', () => {
-    type RouterLayer = { route?: { path: string; methods: Record<string, boolean>; stack: { handle: (req: Request, res: Response, next: () => void) => void }[] } };
+    interface RouterLayer { route?: { path: string; methods: Record<string, boolean>; stack: { handle: (req: Request, res: Response, next: () => void) => void }[] } }
 
     function findRoute(path: string) {
       const layers = (getPluginExpressRouter() as unknown as { stack: RouterLayer[] }).stack;
@@ -290,6 +294,7 @@ describe('plugin router', () => {
       } as unknown as Response;
 
       const layer = findRoute('/async-err/fail');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
 
       // Let the Promise rejection propagate through the catch handler
@@ -310,6 +315,7 @@ describe('plugin router', () => {
       } as unknown as Response;
 
       const layer = findRoute('/async-err2/fail2');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       layer!.route!.stack[0]!.handle({} as Request, mockRes, vi.fn());
 
       await new Promise((resolve) => setTimeout(resolve, 0));

--- a/tests/web/templates.test.ts
+++ b/tests/web/templates.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/web/plugin-router.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/web/plugin-router.js')>();
+  return { ...actual, getPluginNavEntries: vi.fn().mockReturnValue([]) };
+});
+
+import { getPluginNavEntries } from '../../src/web/plugin-router.js';
+
 import {
   renderConversation,
   renderMarkdownExport,
@@ -1772,6 +1780,49 @@ describe('web templates', () => {
         expect(html).toContain('href="/c"');
         expect(html).toContain('Conversations');
       });
+
+      it('shows Login link and omits logout form when isAuthenticated is false', () => {
+        const html = wrapInShell({ title: 'Test', styles: '', body: '<p>test</p>', isAuthenticated: false });
+        expect(html).toContain('href="/login"');
+        expect(html).not.toContain('action="/logout"');
+      });
+
+      it('omits Conversations link when isAuthenticated is false', () => {
+        const html = wrapInShell({ title: 'Test', styles: '', body: '<p>test</p>', isAuthenticated: false });
+        // The nav Conversations link should be absent
+        expect(html).not.toContain('href="/c"');
+      });
+
+      it('omits bottom nav conversation and notifications items when isAuthenticated is false', () => {
+        const html = wrapInShell({ title: 'Test', styles: '', body: '<p>test</p>', isAuthenticated: false });
+        // Conversations and Notifications bottom-nav links are conditional; Dashboard is always present
+        expect(html).not.toContain('aria-label="Conversations"');
+        expect(html).not.toContain('aria-label="Notifications"');
+      });
+
+      it('shows Admin nav link when isAdmin is true', () => {
+        const html = wrapInShell({ title: 'Test', styles: '', body: '<p>test</p>', isAdmin: true });
+        expect(html).toContain('href="/admin/users"');
+        expect(html).toContain('Admin');
+      });
+
+      it('renders plugin nav entry when plugins have web routes registered', () => {
+        vi.mocked(getPluginNavEntries).mockReturnValueOnce([
+          { pluginName: 'hue', label: 'Hue', icon: 'lightbulb', pages: [], public: false },
+        ]);
+        const html = wrapInShell({ title: 'Test', styles: '', body: '<p>test</p>' });
+        expect(html).toContain('href="/p/hue/"');
+        expect(html).toContain('Hue');
+      });
+
+      it('includes plugin subpages in command palette when pages are defined', () => {
+        vi.mocked(getPluginNavEntries).mockReturnValueOnce([
+          { pluginName: 'hue', label: 'Hue', icon: 'lightbulb', pages: [{ name: 'Scenes', path: '/scenes' }], public: false },
+        ]);
+        const html = wrapInShell({ title: 'Test', styles: '', body: '<p>test</p>' });
+        expect(html).toContain('/p/hue/scenes');
+        expect(html).toContain('Hue');
+      });
     });
 
     describe('login page', () => {
@@ -2818,6 +2869,108 @@ describe('web templates', () => {
       const dialogTagMatch = /<dialog\s+id="reset-pw-dialog"[^>]*style="([^"]*)"/i.exec(html);
       expect(dialogTagMatch).not.toBeNull();
       expect(dialogTagMatch?.[1]).toContain('margin:auto');
+    });
+  });
+
+  describe('renderAdminUsers — template unit tests', () => {
+    const baseUser = {
+      id: 1, slackId: 'U01ABC', username: null, displayName: 'Alice',
+      role: 'user' as const, isActive: true, createdAt: 1700000000000, updatedAt: 1700000000000,
+    };
+    const baseInvite = {
+      code: 'deadbeefdeadbeefdeadbeefdeadbeef',
+      createdBy: 1, role: 'user' as const, slackUserId: null,
+      createdAt: 1700000000000, expiresAt: 1700000000000 + 72 * 3600 * 1000,
+      usedAt: null, usedBy: null,
+    };
+
+    // --- User table rows ---
+
+    it('renders empty-state row when users array is empty', () => {
+      const html = renderAdminUsers({ users: [], invites: [] });
+      expect(html).toContain('No users yet.');
+    });
+
+    it('renders active user row with slackId, displayName and active status', () => {
+      const html = renderAdminUsers({ users: [baseUser], invites: [] });
+      expect(html).toContain('U01ABC');
+      expect(html).toContain('Alice');
+      expect(html).toContain('● active');
+    });
+
+    it('applies deactivated class and shows inactive status for inactive user', () => {
+      const html = renderAdminUsers({ users: [{ ...baseUser, isActive: false }], invites: [] });
+      expect(html).toContain('class="deactivated"');
+      expect(html).toContain('○ inactive');
+      expect(html).toContain('activate-btn');
+    });
+
+    it('shows Demote button for admin-role user', () => {
+      const html = renderAdminUsers({ users: [{ ...baseUser, role: 'admin' }], invites: [] });
+      expect(html).toContain('Demote');
+      expect(html).toContain('value="user"');
+    });
+
+    it('shows Promote button for non-admin user', () => {
+      const html = renderAdminUsers({ users: [baseUser], invites: [] });
+      expect(html).toContain('Promote');
+      expect(html).toContain('value="admin"');
+    });
+
+    it('shows Deactivate with danger class for active user action button', () => {
+      const html = renderAdminUsers({ users: [baseUser], invites: [] });
+      expect(html).toContain('class="danger"');
+      expect(html).toContain('Deactivate');
+    });
+
+    it('escapes HTML-special characters in displayName', () => {
+      const html = renderAdminUsers({ users: [{ ...baseUser, displayName: 'Bob <b>bold</b>' }], invites: [] });
+      // The raw tag must not appear as a live element in the user row
+      expect(html).toContain('Bob &lt;b&gt;bold&lt;/b&gt;');
+    });
+
+    // --- Invite table rows ---
+
+    it('renders empty-state row when invites array is empty', () => {
+      const html = renderAdminUsers({ users: [], invites: [] });
+      expect(html).toContain('No active invites.');
+    });
+
+    it('renders Copy URL button when baseUrl is provided', () => {
+      const html = renderAdminUsers({ users: [], invites: [baseInvite], baseUrl: 'http://localhost:8080' });
+      expect(html).toContain('copy-btn');
+      expect(html).toContain('/register?invite=');
+    });
+
+    it('omits Copy URL button when baseUrl is absent', () => {
+      const html = renderAdminUsers({ users: [], invites: [baseInvite] });
+      // copy-btn appears in CSS/JS; check that no data-url attribute is rendered (the actual button)
+      expect(html).not.toContain('data-url=');
+    });
+
+    it('shows pre-linked Slack user ID when slackUserId is set', () => {
+      const html = renderAdminUsers({ users: [], invites: [{ ...baseInvite, slackUserId: 'U09XYZ' }] });
+      expect(html).toContain('U09XYZ');
+    });
+
+    it('shows em-dash placeholder when slackUserId is null', () => {
+      const html = renderAdminUsers({ users: [], invites: [baseInvite] });
+      // slackUserId is null → renders '—'
+      const inviteSection = html.slice(html.indexOf('No active invites.') === -1 ? 0 : 0);
+      expect(html).toContain('—');
+    });
+
+    // --- Flash / error messages ---
+
+    it('renders flash success banner when flash message is provided', () => {
+      const html = renderAdminUsers({ users: [], invites: [], flash: 'User created' });
+      expect(html).toContain('User created');
+      expect(html).toContain('flash');
+    });
+
+    it('renders error banner when error is provided', () => {
+      const html = renderAdminUsers({ users: [], invites: [], error: 'Something went wrong' });
+      expect(html).toContain('Something went wrong');
     });
   });
 });

--- a/tests/web/templates.test.ts
+++ b/tests/web/templates.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../../src/web/plugin-router.js', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import('../../src/web/plugin-router.js')>();
   return { ...actual, getPluginNavEntries: vi.fn().mockReturnValue([]) };
 });
@@ -2955,8 +2956,7 @@ describe('web templates', () => {
 
     it('shows em-dash placeholder when slackUserId is null', () => {
       const html = renderAdminUsers({ users: [], invites: [baseInvite] });
-      // slackUserId is null → renders '—'
-      const inviteSection = html.slice(html.indexOf('No active invites.') === -1 ? 0 : 0);
+      // slackUserId is null → pre-link cell renders '—'
       expect(html).toContain('—');
     });
 


### PR DESCRIPTION
## Summary

Addresses the weakest branch-coverage gaps identified in the post-session coverage audit. All additions are in existing test files — no new files created.

**Expected overall branch coverage improvement: 73% → ~78%+**

## Changes by file

### `tests/web/templates.test.ts`
**`admin-users.ts` branch gap: 11% → ~72%**
- 13 new cases covering user table rows: active/inactive state classes, admin/user role buttons (Demote/Promote), active/inactive action button (danger/activate-btn), HTML escaping in display names
- Invite table rows: copy URL button present/absent based on baseUrl, slackUserId vs em-dash placeholder
- Flash success and error banners

**`shell.ts` / `wrapInShell` auth+nav branches**
- `isAuthenticated: false` → Login link, no logout form, no Conversations link, no bottom-nav items
- `isAdmin: true` → Admin nav link present
- Plugin nav entries render correctly; subpages appear in command palette

Adds `vi.mock` for `plugin-router.js` with `getPluginNavEntries: vi.fn(() => [])` as default (safe for all existing tests since real implementation also returns `[]` with no plugins loaded).

### `tests/web/notifications.test.ts`
**`notifications.ts` time bucket branches: 3 missing buckets now covered**
- `'yesterday'` bucket: notification 25 hours old
- `'this-week'` bucket: notification 4 days old
- `'older'` bucket: notification 10 days old
- Multi-bucket page renders both headers; single-bucket page omits others

### `tests/web/plugin-router.test.ts`
**`plugin-router.ts` branch gap: 50% → ~80%**
- SSE stream endpoint: 503 when manager absent, `addClient` called with correct channel ID, 500 on throw (headers not sent), no-op on throw (headers sent), duplicate registration guard
- Async handler rejection: 500 response, no-op when headers already sent

Adds `vi.mock` for `sse.js` with `getSharedSSEManager: vi.fn()`.

### `tests/services/tools/server-tools.test.ts`
**`server-tools.ts` branch gap: 67% → ~88%**
- `searchContainerLogsTool`: empty output → "No logs found" message; case-sensitive search returns only matching-case lines; `executeCommand` throws → error string
- `dockerImagesTool`: non-zero exitCode → "Error listing images:" + stderr; `executeCommand` throws → "Error listing Docker images:"

## Test plan

- [x] 3319/3319 tests pass (3282 baseline + 37 new)
- [x] TypeScript — no errors
- [x] Lint passes