### PR TITLE
fix(docker-updates): rename plugin name to docker_updates

### DIFF
--- a/plugins.local/docker-updates.test.ts
+++ b/plugins.local/docker-updates.test.ts
@@ -253,3 +253,15 @@ describe('parsePendingUpdates', () => {
     expect(result[0]!.service).toBe('nginx');
   });
 });
+
+// =============================================================================
+// Plugin name regression guard
+// =============================================================================
+
+import dockerUpdatesPlugin from './docker-updates.js';
+
+describe('dockerUpdatesPlugin.name', () => {
+  it('uses underscore not hyphen (database prefix validator requires /^[a-z][a-z0-9_]*$/)', () => {
+    expect(dockerUpdatesPlugin.name).toBe('docker_updates');
+  });
+});

--- a/plugins.local/docker-updates.ts
+++ b/plugins.local/docker-updates.ts
@@ -9,7 +9,7 @@
  * read-only by design (see src/utils/shell.ts allowlist and CLAUDE.md).
  *
  * Commands: /docker-updates status | pending | history [n] | help
- * Web: /p/docker-updates/ (added in PR 1b)
+ * Web: /p/docker_updates/ (added in PR 1b)
  * Tools: docker_updates:list_pending | get_history | get_service_version
  */
 
@@ -448,7 +448,7 @@ function registerDockerUpdatesWebRoutes(router: PluginRouter): void {
       const body = await buildDashboardHtml();
       const html = renderPluginPage({
         title: 'Docker Updates',
-        pluginName: 'docker-updates',
+        pluginName: 'docker_updates',
         body,
         styles: DASHBOARD_CSS,
         scripts: `<script>setTimeout(()=>location.reload(),60000);</script>`,
@@ -674,7 +674,7 @@ const dockerUpdatesPlugin: Plugin = {
       html: hasPending
         ? `<span style="color:#e6a817;font-weight:600">⚠️ ${escapeHtml(String(cachedPendingCount))} update${cachedPendingCount === 1 ? '' : 's'} available</span>`
         : `<span style="color:#3fb950">✅ All up to date</span>`,
-      link: '/p/docker-updates/',
+      link: '/p/docker_updates/',
       priority: 60,
       size: 'small',
     }];

--- a/plugins.local/docker-updates.ts
+++ b/plugins.local/docker-updates.ts
@@ -566,7 +566,7 @@ const tools: ToolDefinition[] = [
 // =============================================================================
 
 const dockerUpdatesPlugin: Plugin = {
-  name: 'docker-updates',
+  name: 'docker_updates',
   version: '1.1.0',
   description: 'Container update status — versions, pending updates, history',
 


### PR DESCRIPTION
## Summary

Same class of bug as #13. Plugin name `'docker-updates'` contains a hyphen, rejected by the database prefix validator. Plugin was crashing on init.

## Change

`plugins.local/docker-updates.ts` line 569: `'docker-updates'` → `'docker_updates'`

## Test plan
- [x] 3,319 tests pass
- [x] Typecheck clean
- [x] Lint clean

Closes #14