### PR TITLE
perf: request timing middleware + health cache pre-warm

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import { closeUserStore, getUserStore, resolveUserStoreDbPath } from './services
 import { evaluateAuthStartup } from './services/auth-startup.js';
 import { startBackupSchedule } from './services/db-backup.js';
 import { startWebServer, stopWebServer } from './web/index.js';
+import { getServerHealth } from './services/server-health.js';
 import { setConnected, setDisconnected } from './services/socket-mode-status.js';
 
 let stopBackupSchedule: (() => void) | null = null;
@@ -173,6 +174,10 @@ async function main(): Promise<void> {
     // Start web server if enabled
     if (config.web?.enabled) {
       await startWebServer(config.web);
+      // Pre-warm health cache so the first dashboard load doesn't block on 5 shell commands
+      getServerHealth().catch((err: unknown) =>
+        logger.warn('Health cache pre-warm failed', { error: err instanceof Error ? err.message : String(err) })
+      );
     }
 
     // Register slash commands (async to load context)

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -227,6 +227,28 @@ export async function startWebServer(webConfig: WebConfig): Promise<void> {
   app.use(express.urlencoded({ extended: false }));
   app.use(express.json());
 
+  // Request timing — logs slow requests (all response types) and adds X-Response-Time header (send paths only)
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    const start = Date.now();
+
+    // 'finish' fires for all response types: send, json, redirect, SSE end — comprehensive coverage
+    res.on('finish', () => {
+      const duration = Date.now() - start;
+      if (duration > 500) {
+        logger.warn('Slow request', { method: req.method, path: req.path, status: res.statusCode, durationMs: duration });
+      }
+    });
+
+    // X-Response-Time header on res.send() paths (normal routes, API endpoints) for DevTools visibility
+    const originalSend = res.send.bind(res);
+    res.send = function (body: Parameters<typeof res.send>[0]) {
+      res.setHeader('X-Response-Time', String(Date.now() - start) + 'ms');
+      return originalSend(body);
+    };
+
+    next();
+  });
+
   // Security headers
   app.use((_req: Request, res: Response, next: NextFunction) => {
     res.setHeader('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
## Summary
- Add request timing middleware to surface slow routes (logs >500ms, adds `X-Response-Time` header)
- Pre-warm the server health cache at startup so first dashboard load is instant

## Context
Diagnostics confirmed nautilus is not under system load (load avg 0.15, 20GB RAM free, 0 swap, tiny SQLite DB). Slowness is app-level. The main bottleneck is Claude CLI process spawn time (~1-2s per `/ask` call — addressed separately by switching to `CLAUDE_PROVIDER=sdk`). These changes give immediate visibility into which routes are slow and eliminate the cold-cache hit on first dashboard load after restart.

## Changes
- `src/web/server.ts`: timing middleware using `finish` listener (covers all response types: send, redirect, SSE end) + `res.send()` override to write `X-Response-Time` header on normal routes
- `src/app.ts`: fire-and-forget `getServerHealth()` call after `startWebServer()` to warm the 60-second health cache before any user hits `/`

## Testing
- [ ] All 3321 tests pass
- [ ] Lint and typecheck clean
- [ ] After deploy: check `pm2 logs` for `Slow request` entries; browser DevTools Network tab shows `X-Response-Time` on dashboard requests