### PR TITLE
chore(dev): auto-sync Ansible role plugin files before npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "start": "node dist/app.js",
     "dev": "tsx watch src/app.ts",
+    "pretest": "node scripts/sync-role-plugins.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/sync-role-plugins.js
+++ b/scripts/sync-role-plugins.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Copies plugin source files from the Ansible role into plugins.local/ so that
+ * Vitest can discover and run their tests without a manual copy step.
+ *
+ * Runs automatically as the "pretest" npm lifecycle hook.
+ * Safe to run repeatedly — uses recursive copy with overwrite.
+ *
+ * Source:  home-server-ansible/roles/slack_monitor/files/
+ * Target:  home-server-ansible/slack-server-monitor/plugins.local/
+ */
+
+import { cpSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SSM_ROOT = join(__dirname, '..');
+const ROLE_FILES = join(SSM_ROOT, '..', 'roles', 'slack_monitor', 'files');
+const PLUGINS_LOCAL = join(SSM_ROOT, 'plugins.local');
+
+if (!existsSync(ROLE_FILES)) {
+  // Running outside the Ansible repo (e.g., standalone SSM checkout) — skip silently.
+  process.exit(0);
+}
+
+mkdirSync(PLUGINS_LOCAL, { recursive: true });
+
+const entries = [
+  { src: join(ROLE_FILES, 'media-organizer'), dst: join(PLUGINS_LOCAL, 'media-organizer') },
+  { src: join(ROLE_FILES, 'media-organizer.ts'), dst: join(PLUGINS_LOCAL, 'media-organizer.ts') },
+];
+
+for (const { src, dst } of entries) {
+  if (existsSync(src)) {
+    cpSync(src, dst, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `pretest` lifecycle hook and `scripts/sync-role-plugins.js` so that plugin source files committed in the parent Ansible repo (`roles/slack_monitor/files/`) are automatically copied into `plugins.local/` before every `npm test` run. Closes the "manual copy" friction that made Vitest unable to discover plugin tests without setup.

## Changes

- **`scripts/sync-role-plugins.js`** — copies `roles/slack_monitor/files/media-organizer/` and `media-organizer.ts` into `plugins.local/`, no-ops silently when `../roles/` doesn't exist (standalone SSM checkout outside the Ansible repo)
- **`package.json`** — adds `"pretest": "node scripts/sync-role-plugins.js"` lifecycle hook

## Test plan

- [x] `npm test` from a clean `plugins.local/` (only container-logs and docker-updates present) auto-discovers and runs plugin test files — 133 test files / 3361 tests pass
- [x] Script is a no-op when run outside the Ansible repo (exits 0 when `../roles` doesn't exist)

Tracked in swamp-dev/ansible#174.