### PR TITLE
chore(agentbox): initialize vendor submodule and wire CI binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,19 @@ jobs:
           submodules: recursive
           token: ${{ secrets.PARENT_REPO_TOKEN || github.token }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Get submodule SHA for cache key
         id: submodule-sha
         run: |
           SHA=$(git ls-tree HEAD vendor/agentbox | awk '{print $3}')
+          if [ -z "$SHA" ]; then
+            echo "ERROR: vendor/agentbox not found in tree — submodule commit missing" >&2
+            exit 1
+          fi
           echo "cache-key=agentbox-bin-${SHA}" >> $GITHUB_OUTPUT
 
       - name: Restore agentbox binary cache
@@ -66,6 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          submodules: recursive
           token: ${{ secrets.PARENT_REPO_TOKEN || github.token }}
 
       - name: Setup Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,50 @@ env:
   NODE_VERSION: '20'
 
 jobs:
+  # Build the agentbox Go binary from the vendor/agentbox submodule.
+  # Cached by submodule commit SHA — only rebuilds when the submodule pointer moves.
+  agentbox-build:
+    name: Build agentbox binary
+    runs-on: ubuntu-latest
+    outputs:
+      cache-key: ${{ steps.submodule-sha.outputs.cache-key }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.PARENT_REPO_TOKEN || github.token }}
+
+      - name: Get submodule SHA for cache key
+        id: submodule-sha
+        run: |
+          SHA=$(git ls-tree HEAD vendor/agentbox | awk '{print $3}')
+          echo "cache-key=agentbox-bin-${SHA}" >> $GITHUB_OUTPUT
+
+      - name: Restore agentbox binary cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: dist/bin/agentbox
+          key: ${{ steps.submodule-sha.outputs.cache-key }}
+
+      - name: Setup Go
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - name: Build agentbox binary
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: npm run agentbox:build
+
+      - name: Save agentbox binary cache
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: dist/bin/agentbox
+          key: ${{ steps.submodule-sha.outputs.cache-key }}
+
   # Shared install job to avoid downloading dependencies 4x
   install:
     name: Install Dependencies
@@ -114,7 +158,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: install
+    needs: [install, agentbox-build]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -130,6 +174,13 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
+          fail-on-cache-miss: true
+
+      - name: Restore agentbox binary
+        uses: actions/cache/restore@v4
+        with:
+          path: dist/bin/agentbox
+          key: ${{ needs.agentbox-build.outputs.cache-key }}
           fail-on-cache-miss: true
 
       - name: Run tests with coverage
@@ -170,7 +221,7 @@ jobs:
   smoke:
     name: Smoke Tests
     runs-on: ubuntu-latest
-    needs: [install, build]
+    needs: [install, build, agentbox-build]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -186,6 +237,13 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
+          fail-on-cache-miss: true
+
+      - name: Restore agentbox binary
+        uses: actions/cache/restore@v4
+        with:
+          path: dist/bin/agentbox
+          key: ${{ needs.agentbox-build.outputs.cache-key }}
           fail-on-cache-miss: true
 
       - name: Run smoke tests
@@ -269,7 +327,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [install, lint, typecheck, build, test, smoke, e2e, security]
+    needs: [install, agentbox-build, lint, typecheck, build, test, smoke, e2e, security]
     if: always()
     steps:
       - name: Check all jobs passed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Full details: [docs/security.md](docs/security.md)
 
 ```bash
 npm run setup           # Interactive setup wizard (creates/updates .env)
-npm install             # Install dependencies
+npm install             # Install dependencies (also initializes vendor/agentbox submodule and builds the Go binary if Go is installed)
 npm run dev             # Hot reload development server
 npm test                # Run tests
 npm run typecheck       # Type checking

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "setup": "tsx src/setup/wizard.ts",
     "screenshots": "tsx scripts/take-screenshots.ts",
     "manage-users": "tsx src/cli/manage-users.ts",
-    "agentbox:build": "bash scripts/build-agentbox.sh"
+    "agentbox:build": "bash scripts/build-agentbox.sh",
+    "prepare": "git submodule update --init --recursive && npm run agentbox:build"
   },
   "keywords": [
     "slack",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "author": "",
   "license": "MIT",
+  "private": true,
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## Summary

- Commits the `vendor/agentbox` git submodule pointer (was in `.gitmodules` but never added to the tree)
- Adds a `prepare` npm lifecycle script so `npm install` auto-initializes the submodule and builds the Go binary
- Adds a dedicated `agentbox-build` CI job that builds the binary with a SHA-keyed cache (no rebuild on unrelated pushes)
- Wires `dist/bin/agentbox` into the `test` and `smoke` CI jobs via cache restore before tests run
- Adds `"private": true` to prevent accidental `npm publish`

## Changes

- `vendor/agentbox` — new: submodule pointer (swamp-dev/agentbox @ HEAD)
- `package.json` — add `prepare` script + `"private": true`
- `.github/workflows/ci.yml` — new `agentbox-build` job; `install` job gets `submodules: recursive`; `test`/`smoke` restore binary before running; `ci-success` includes `agentbox-build`
- `CLAUDE.md` — note that `npm install` handles submodule init automatically

## Testing

- [x] `npm install` runs `prepare`, initializes submodule, and builds `dist/bin/agentbox`
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 3359 tests passed (131 files)
- CI will verify binary is present before test:coverage runs

## Closes

Closes #24