### PR TITLE
test(app): add lifecycle tests for startup and graceful shutdown

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -201,5 +201,5 @@ async function main(): Promise<void> {
   }
 }
 
-/* c8 ignore next */
+/* v8 ignore next */
 if (!process.env.VITEST) void main();

--- a/src/app.ts
+++ b/src/app.ts
@@ -125,6 +125,8 @@ async function shutdown(signal: string): Promise<void> {
 process.on('SIGTERM', () => void shutdown('SIGTERM'));
 process.on('SIGINT', () => void shutdown('SIGINT'));
 
+export { main, shutdown };
+
 // Start the app
 async function main(): Promise<void> {
   try {
@@ -199,4 +201,5 @@ async function main(): Promise<void> {
   }
 }
 
-void main();
+/* c8 ignore next */
+if (!process.env.VITEST) void main();

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,4 +1,119 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ─── hoisted mock objects ──────────────────────────────────────────────────
+const mocks = vi.hoisted(() => ({
+  mockStart: vi.fn().mockResolvedValue(undefined),
+  mockStop: vi.fn().mockResolvedValue(undefined),
+  mockUse: vi.fn(),
+  mockError: vi.fn(),
+  mockClientOn: vi.fn(),
+  mockCloseConversationStore: vi.fn(),
+  mockCloseUserStore: vi.fn(),
+  mockRegisterCommands: vi.fn().mockResolvedValue(undefined),
+  mockDestroyPlugins: vi.fn().mockResolvedValue(undefined),
+  mockStopRateLimitCleanup: vi.fn(),
+  mockStopWebServer: vi.fn().mockResolvedValue(undefined),
+  mockEvaluateAuthStartup: vi.fn().mockReturnValue({ ok: true, level: 'silent' }),
+  mockUserStoreBootstrap: vi.fn().mockReturnValue({ created: 0, skipped: [] }),
+  mockUserStoreListAll: vi.fn().mockReturnValue([]),
+  mockUserStoreClose: vi.fn(),
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ─── module mocks (hoisted by vitest above all imports) ───────────────────
+vi.mock('@slack/bolt', () => ({
+  // Must use function (not arrow) so it can be called as a constructor
+  App: vi.fn(function () {
+    return {
+      use: mocks.mockUse,
+      error: mocks.mockError,
+      start: mocks.mockStart,
+      stop: mocks.mockStop,
+      receiver: { client: { on: mocks.mockClientOn } },
+    };
+  }),
+  LogLevel: { DEBUG: 'DEBUG', INFO: 'INFO', WARN: 'WARN', ERROR: 'ERROR' },
+}));
+
+vi.mock('../src/config/index.js', () => ({
+  config: {
+    slack: { botToken: 'xoxb-test', appToken: 'xapp-test' },
+    logging: { level: 'info' },
+    authorization: { userIds: ['U123'] },
+    rateLimit: { max: 10, windowSeconds: 60 },
+    claude: undefined,
+    web: undefined,
+  },
+}));
+
+vi.mock('../src/utils/logger.js', () => ({ logger: mocks.mockLogger }));
+
+vi.mock('../src/middleware/index.js', () => ({
+  authorizeMiddleware: vi.fn(),
+  rateLimitMiddleware: vi.fn(),
+  auditLogMiddleware: vi.fn(),
+  stopRateLimitCleanup: mocks.mockStopRateLimitCleanup,
+}));
+
+vi.mock('../src/commands/index.js', () => ({
+  registerCommands: mocks.mockRegisterCommands,
+}));
+
+vi.mock('../src/plugins/index.js', () => ({
+  registerPlugins: vi.fn().mockResolvedValue(undefined),
+  destroyPlugins: mocks.mockDestroyPlugins,
+  getPluginTools: vi.fn().mockReturnValue([]),
+  getLoadedPlugins: vi.fn().mockReturnValue([]),
+  getPluginHelpData: vi.fn().mockReturnValue([]),
+  getPluginWidgets: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../src/services/user-store.js', () => ({
+  getUserStore: vi.fn().mockImplementation(() => ({
+    bootstrap: mocks.mockUserStoreBootstrap,
+    listAll: mocks.mockUserStoreListAll,
+    close: mocks.mockUserStoreClose,
+  })),
+  closeUserStore: mocks.mockCloseUserStore,
+  resolveUserStoreDbPath: vi.fn().mockReturnValue('./data/users.db'),
+}));
+
+vi.mock('../src/services/conversation-store.js', () => ({
+  getConversationStore: vi.fn().mockReturnValue({
+    cleanupExpired: vi.fn().mockReturnValue(0),
+    close: vi.fn(),
+    getDatabase: vi.fn(),
+  }),
+  closeConversationStore: mocks.mockCloseConversationStore,
+}));
+
+vi.mock('../src/services/auth-startup.js', () => ({
+  evaluateAuthStartup: mocks.mockEvaluateAuthStartup,
+}));
+
+vi.mock('../src/services/db-backup.js', () => ({
+  startBackupSchedule: vi.fn().mockReturnValue(vi.fn()),
+}));
+
+vi.mock('../src/web/index.js', () => ({
+  startWebServer: vi.fn().mockResolvedValue(undefined),
+  stopWebServer: mocks.mockStopWebServer,
+}));
+
+vi.mock('../src/services/server-health.js', () => ({
+  getServerHealth: vi.fn().mockResolvedValue({}),
+}));
+
+// ─── static imports resolved after mocks are registered ───────────────────
+import { getUserStore } from '../src/services/user-store.js';
+import { main, shutdown } from '../src/app.js';
+
+// ─── socket-mode-status tests ─────────────────────────────────────────────
 
 describe('socket-mode-status', () => {
   beforeEach(() => {
@@ -37,5 +152,78 @@ describe('socket-mode-status', () => {
     expect(status.connected).toBe(false);
     expect(status.lastDisconnectedAt).toBeTruthy();
     expect(status.lastConnectedAt).toBeTruthy();
+  });
+});
+
+// ─── app lifecycle tests ───────────────────────────────────────────────────
+
+describe('app lifecycle', () => {
+  let mockProcessExit: { mockRestore: () => void };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockStart.mockResolvedValue(undefined);
+    mocks.mockStop.mockResolvedValue(undefined);
+    mocks.mockRegisterCommands.mockResolvedValue(undefined);
+    mocks.mockDestroyPlugins.mockResolvedValue(undefined);
+    mocks.mockEvaluateAuthStartup.mockReturnValue({ ok: true, level: 'silent' });
+    mocks.mockUserStoreBootstrap.mockReturnValue({ created: 0, skipped: [] });
+    mocks.mockUserStoreListAll.mockReturnValue([]);
+    vi.mocked(getUserStore).mockImplementation(
+      () =>
+        ({
+          bootstrap: mocks.mockUserStoreBootstrap,
+          listAll: mocks.mockUserStoreListAll,
+          close: mocks.mockUserStoreClose,
+        }) as unknown as ReturnType<typeof getUserStore>,
+    );
+    mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    mockProcessExit.mockRestore();
+  });
+
+  it('initializes stores before registerCommands resolves', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(getUserStore).mockImplementationOnce(() => {
+      callOrder.push('getUserStore');
+      return {
+        bootstrap: mocks.mockUserStoreBootstrap,
+        listAll: mocks.mockUserStoreListAll,
+        close: mocks.mockUserStoreClose,
+      } as unknown as ReturnType<typeof getUserStore>;
+    });
+    mocks.mockRegisterCommands.mockImplementationOnce(async () => {
+      callOrder.push('registerCommands');
+    });
+
+    await main();
+
+    expect(callOrder).toContain('getUserStore');
+    expect(callOrder).toContain('registerCommands');
+    expect(callOrder.indexOf('getUserStore')).toBeLessThan(callOrder.indexOf('registerCommands'));
+  });
+
+  it('closes all stores when shutdown is triggered', async () => {
+    await shutdown('SIGTERM');
+
+    expect(mocks.mockCloseConversationStore).toHaveBeenCalled();
+    expect(mocks.mockCloseUserStore).toHaveBeenCalled();
+  });
+
+  it('starts the app even when a plugin initialization error is handled internally', async () => {
+    // registerPlugins (called inside registerCommands) catches individual plugin errors
+    // and does NOT rethrow — matching the actual behavior in src/plugins/loader.ts.
+    // Verify that when registerCommands resolves (despite an internal plugin error),
+    // app.start() is still called and the app comes up.
+    mocks.mockRegisterCommands.mockImplementationOnce(async () => {
+      mocks.mockLogger.error('Failed to initialize plugin', { name: 'bad-plugin', error: 'Init error' });
+      // resolves without throwing — error was caught inside registerPlugins
+    });
+
+    await main();
+
+    expect(mocks.mockStart).toHaveBeenCalled();
   });
 });

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -205,25 +205,43 @@ describe('app lifecycle', () => {
     expect(callOrder.indexOf('getUserStore')).toBeLessThan(callOrder.indexOf('registerCommands'));
   });
 
-  it('closes all stores when shutdown is triggered', async () => {
+  it('closes conversation store and user store on shutdown', async () => {
+    // Verifies the two stores app.ts owns directly. Web-server-owned stores
+    // (session, notification, quicklinks) are covered by stopWebServer, which
+    // is asserted via the mock call count below.
     await shutdown('SIGTERM');
 
     expect(mocks.mockCloseConversationStore).toHaveBeenCalled();
     expect(mocks.mockCloseUserStore).toHaveBeenCalled();
+    expect(mocks.mockStopWebServer).toHaveBeenCalled();
   });
 
-  it('starts the app even when a plugin initialization error is handled internally', async () => {
-    // registerPlugins (called inside registerCommands) catches individual plugin errors
-    // and does NOT rethrow — matching the actual behavior in src/plugins/loader.ts.
-    // Verify that when registerCommands resolves (despite an internal plugin error),
-    // app.start() is still called and the app comes up.
+  it('starts the app when registerCommands resolves after catching a plugin error internally', async () => {
+    // registerPlugins catches individual plugin init errors and does NOT rethrow
+    // (see src/plugins/loader.ts). Simulate that path: registerCommands resolves
+    // while having logged a plugin failure, and verify app.start() is still called.
     mocks.mockRegisterCommands.mockImplementationOnce(async () => {
       mocks.mockLogger.error('Failed to initialize plugin', { name: 'bad-plugin', error: 'Init error' });
-      // resolves without throwing — error was caught inside registerPlugins
     });
 
     await main();
 
     expect(mocks.mockStart).toHaveBeenCalled();
+  });
+
+  it('exits with code 1 and does not call app.start() when startup throws', async () => {
+    // Covers the main() catch block: if any startup step throws (e.g. an
+    // unrecoverable plugin system failure), the error is logged and the
+    // process exits — it never reaches app.start().
+    mocks.mockRegisterCommands.mockRejectedValueOnce(new Error('unrecoverable plugin failure'));
+
+    await main();
+
+    expect(mocks.mockStart).not.toHaveBeenCalled();
+    expect(mocks.mockLogger.error).toHaveBeenCalledWith(
+      'Failed to start app',
+      expect.objectContaining({ error: 'unrecoverable plugin failure' }),
+    );
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary

- Exports `main()` and `shutdown()` from `src/app.ts`, guarded behind `process.env.VITEST` so the bot never auto-starts under test
- Adds `describe('app lifecycle')` block to `tests/app.test.ts` with four tests:
  1. `getUserStore` is called before `registerCommands` resolves (call-order tracking)
  2. `shutdown('SIGTERM')` calls `closeConversationStore()`, `closeUserStore()`, and `stopWebServer()`
  3. `app.start()` is called when `registerCommands` resolves despite an internal plugin error
  4. `app.start()` is NOT called when a startup step throws unrecoverably (`process.exit(1)` is verified)

## Changes

- `src/app.ts` — export `main`, `shutdown`; VITEST guard on auto-start; `v8 ignore` directive on guard line
- `tests/app.test.ts` — add `vi.hoisted()` mocks + new lifecycle describe block; existing socket-mode-status tests untouched

## Testing

- [x] 3363 tests pass (131 files), no regressions
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- No real SQLite files or Slack connections created

## Closes

Closes #21