### PR TITLE
fix(stores): enforce consistent singleton pattern via createStoreSingleton factory

### DIFF
--- a/src/services/context-store.ts
+++ b/src/services/context-store.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { logger } from '../utils/logger.js';
+import { createStoreSingleton } from './store-factory.js';
 
 /**
  * Channel context selection record
@@ -111,23 +112,12 @@ export class ContextStore {
   }
 }
 
-// Singleton instance - lazily initialized
-let store: ContextStore | null = null;
+const contextSingleton = createStoreSingleton<ContextStore>('ContextStore');
 
-/**
- * Get the context store singleton
- */
 export function getContextStore(dbPath: string): ContextStore {
-  store ??= new ContextStore(dbPath);
-  return store;
+  return contextSingleton.get(dbPath, () => new ContextStore(dbPath));
 }
 
-/**
- * Close the context store
- */
 export function closeContextStore(): void {
-  if (store) {
-    store.close();
-    store = null;
-  }
+  contextSingleton.close();
 }

--- a/src/services/conversation-store.ts
+++ b/src/services/conversation-store.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'crypto';
 import path from 'path';
 import fs from 'fs';
 import { logger } from '../utils/logger.js';
+import { createStoreSingleton } from './store-factory.js';
 
 /**
  * Safely truncate a string without splitting multi-byte UTF-8 characters
@@ -1322,23 +1323,12 @@ export class ConversationStore {
   }
 }
 
-// Singleton instance - lazily initialized
-let store: ConversationStore | null = null;
+const conversationSingleton = createStoreSingleton<ConversationStore>('ConversationStore');
 
-/**
- * Get the conversation store singleton
- */
 export function getConversationStore(dbPath: string, ttlHours = 24): ConversationStore {
-  store ??= new ConversationStore(dbPath, ttlHours);
-  return store;
+  return conversationSingleton.get(dbPath, () => new ConversationStore(dbPath, ttlHours));
 }
 
-/**
- * Close the conversation store
- */
 export function closeConversationStore(): void {
-  if (store) {
-    store.close();
-    store = null;
-  }
+  conversationSingleton.close();
 }

--- a/src/services/invite-store.ts
+++ b/src/services/invite-store.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { z } from 'zod';
+import { createStoreSingleton } from './store-factory.js';
 import { logger } from '../utils/logger.js';
 import {
   SlackUserIdSchema,
@@ -207,27 +208,12 @@ function mapRow(row: InviteRow): InviteCode {
   };
 }
 
-let store: InviteStore | null = null;
-let storeDbPath: string | null = null;
+const inviteSingleton = createStoreSingleton<InviteStore>('InviteStore');
 
 export function getInviteStore(dbPath: string): InviteStore {
-  if (store && storeDbPath !== dbPath) {
-    throw new Error(
-      `InviteStore already initialized at ${storeDbPath ?? '<unknown>'} — ` +
-        `cannot re-initialize at ${dbPath}. Call closeInviteStore() first.`,
-    );
-  }
-  if (!store) {
-    store = new InviteStore(dbPath);
-    storeDbPath = dbPath;
-  }
-  return store;
+  return inviteSingleton.get(dbPath, () => new InviteStore(dbPath));
 }
 
 export function closeInviteStore(): void {
-  if (store) {
-    store.close();
-    store = null;
-    storeDbPath = null;
-  }
+  inviteSingleton.close();
 }

--- a/src/services/notification-store.ts
+++ b/src/services/notification-store.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { logger } from '../utils/logger.js';
 import { getEventBus } from './event-bus.js';
+import { createStoreSingleton } from './store-factory.js';
 
 /**
  * Notification record
@@ -217,22 +218,12 @@ function mapRow(row: Record<string, unknown>): Notification {
 
 // ─── Singleton ───────────────────────────────────────────────────────
 
-let store: NotificationStore | null = null;
+const notificationSingleton = createStoreSingleton<NotificationStore>('NotificationStore');
 
-/**
- * Get the notification store singleton
- */
 export function getNotificationStore(dbPath: string): NotificationStore {
-  store ??= new NotificationStore(dbPath);
-  return store;
+  return notificationSingleton.get(dbPath, () => new NotificationStore(dbPath));
 }
 
-/**
- * Close the notification store
- */
 export function closeNotificationStore(): void {
-  if (store) {
-    store.close();
-    store = null;
-  }
+  notificationSingleton.close();
 }

--- a/src/services/quick-links-store.ts
+++ b/src/services/quick-links-store.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { logger } from '../utils/logger.js';
+import { createStoreSingleton } from './store-factory.js';
 
 /**
  * Quick link record
@@ -160,22 +161,12 @@ function mapRow(row: Record<string, unknown>): QuickLink {
 
 // ─── Singleton ───────────────────────────────────────────────────────
 
-let store: QuickLinksStore | null = null;
+const quickLinksSingleton = createStoreSingleton<QuickLinksStore>('QuickLinksStore');
 
-/**
- * Get the quick links store singleton
- */
 export function getQuickLinksStore(dbPath: string): QuickLinksStore {
-  store ??= new QuickLinksStore(dbPath);
-  return store;
+  return quickLinksSingleton.get(dbPath, () => new QuickLinksStore(dbPath));
 }
 
-/**
- * Close the quick links store
- */
 export function closeQuickLinksStore(): void {
-  if (store) {
-    store.close();
-    store = null;
-  }
+  quickLinksSingleton.close();
 }

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { logger } from '../utils/logger.js';
+import { createStoreSingleton } from './store-factory.js';
 
 /**
  * Web session record
@@ -149,23 +150,12 @@ export class SessionStore {
   }
 }
 
-// Singleton instance
-let store: SessionStore | null = null;
+const sessionSingleton = createStoreSingleton<SessionStore>('SessionStore');
 
-/**
- * Get the session store singleton
- */
 export function getSessionStore(dbPath: string, ttlHours = 72): SessionStore {
-  store ??= new SessionStore(dbPath, ttlHours);
-  return store;
+  return sessionSingleton.get(dbPath, () => new SessionStore(dbPath, ttlHours));
 }
 
-/**
- * Close the session store
- */
 export function closeSessionStore(): void {
-  if (store) {
-    store.close();
-    store = null;
-  }
+  sessionSingleton.close();
 }

--- a/src/services/store-factory.ts
+++ b/src/services/store-factory.ts
@@ -1,0 +1,52 @@
+/**
+ * Factory for consistent store singleton behaviour across all store files.
+ *
+ * All stores must enforce the same invariant: a second call with a *different*
+ * dbPath is a programming error (two parts of the app disagree on where the
+ * database lives). Previously half the stores enforced this strictly and the
+ * other half silently reused the first path — this factory makes the strict
+ * behaviour the only behaviour.
+ */
+
+export interface StoreSingleton<T extends { close(): void }> {
+  /** Return the existing instance, or create it with `factory` on first call. */
+  get(dbPath: string, factory: () => T): T;
+  /** Close the store and clear state. No-op if not initialized. */
+  close(): void;
+  /** Clear state WITHOUT calling close(). For use in test teardown only. */
+  _resetForTests(): void;
+}
+
+export function createStoreSingleton<T extends { close(): void }>(storeName: string): StoreSingleton<T> {
+  let instance: T | null = null;
+  let instancePath: string | null = null;
+
+  return {
+    get(dbPath: string, factory: () => T): T {
+      if (instance !== null && instancePath !== dbPath) {
+        throw new Error(
+          `${storeName} already initialized at ${instancePath ?? '<unknown>'} — ` +
+            `cannot re-initialize at ${dbPath}. Call close() first.`,
+        );
+      }
+      if (instance === null) {
+        instance = factory();
+        instancePath = dbPath;
+      }
+      return instance;
+    },
+
+    close(): void {
+      if (instance !== null) {
+        instance.close();
+        instance = null;
+        instancePath = null;
+      }
+    },
+
+    _resetForTests(): void {
+      instance = null;
+      instancePath = null;
+    },
+  };
+}

--- a/src/services/user-store.ts
+++ b/src/services/user-store.ts
@@ -4,6 +4,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { logger } from '../utils/logger.js';
+import { createStoreSingleton } from './store-factory.js';
 import {
   CreateUserInputSchema,
   PasswordSchema,
@@ -422,27 +423,12 @@ export function resolveUserStoreDbPath(claudeDbPath: string | undefined): string
   return claudeDbPath ?? './data/users.db';
 }
 
-let store: UserStore | null = null;
-let storeDbPath: string | null = null;
+const userSingleton = createStoreSingleton<UserStore>('UserStore');
 
 export function getUserStore(dbPath: string): UserStore {
-  if (store && storeDbPath !== dbPath) {
-    throw new Error(
-      `UserStore already initialized at ${storeDbPath ?? '<unknown>'} — ` +
-        `cannot re-initialize at ${dbPath}. Call closeUserStore() first.`,
-    );
-  }
-  if (!store) {
-    store = new UserStore(dbPath);
-    storeDbPath = dbPath;
-  }
-  return store;
+  return userSingleton.get(dbPath, () => new UserStore(dbPath));
 }
 
 export function closeUserStore(): void {
-  if (store) {
-    store.close();
-    store = null;
-    storeDbPath = null;
-  }
+  userSingleton.close();
 }

--- a/tests/services/store-factory.test.ts
+++ b/tests/services/store-factory.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStoreSingleton } from '../../src/services/store-factory.js';
+
+class MockStore {
+  readonly dbPath: string;
+  closeCalled = false;
+
+  constructor(dbPath: string) {
+    this.dbPath = dbPath;
+  }
+
+  close(): void {
+    this.closeCalled = true;
+  }
+}
+
+describe('createStoreSingleton', () => {
+  let singleton: ReturnType<typeof createStoreSingleton<MockStore>>;
+
+  beforeEach(() => {
+    singleton = createStoreSingleton<MockStore>('MockStore');
+  });
+
+  it('returns the same instance when called twice with the same path', () => {
+    const a = singleton.get('/db/a.db', () => new MockStore('/db/a.db'));
+    const b = singleton.get('/db/a.db', () => new MockStore('/db/a.db'));
+    expect(a).toBe(b);
+  });
+
+  it('does not call the factory function on the second same-path call', () => {
+    let factoryCalls = 0;
+    const factory = () => {
+      factoryCalls++;
+      return new MockStore('/db/a.db');
+    };
+    singleton.get('/db/a.db', factory);
+    singleton.get('/db/a.db', factory);
+    expect(factoryCalls).toBe(1);
+  });
+
+  it('throws when called with a different path after initialization', () => {
+    singleton.get('/old.db', () => new MockStore('/old.db'));
+    expect(() => singleton.get('/new.db', () => new MockStore('/new.db'))).toThrow(Error);
+  });
+
+  it('error message identifies store name, old path, and new path', () => {
+    singleton.get('/old.db', () => new MockStore('/old.db'));
+    expect(() => singleton.get('/new.db', () => new MockStore('/new.db'))).toThrow(
+      /MockStore.*\/old\.db.*\/new\.db/,
+    );
+  });
+
+  it('close() calls the store close() method and clears state', () => {
+    const store = singleton.get('/db.db', () => new MockStore('/db.db'));
+    singleton.close();
+    expect(store.closeCalled).toBe(true);
+  });
+
+  it('close() allows re-initialization at a new path after closing', () => {
+    singleton.get('/first.db', () => new MockStore('/first.db'));
+    singleton.close();
+    const second = singleton.get('/second.db', () => new MockStore('/second.db'));
+    expect(second.dbPath).toBe('/second.db');
+  });
+
+  it('close() is a no-op when the singleton has not been initialized', () => {
+    expect(() => singleton.close()).not.toThrow();
+  });
+
+  it('_resetForTests() allows re-initialization without calling close on the store', () => {
+    const store = singleton.get('/db.db', () => new MockStore('/db.db'));
+    singleton._resetForTests();
+    expect(store.closeCalled).toBe(false);
+  });
+
+  it('_resetForTests() allows a new path after reset', () => {
+    singleton.get('/old.db', () => new MockStore('/old.db'));
+    singleton._resetForTests();
+    const store = singleton.get('/new.db', () => new MockStore('/new.db'));
+    expect(store.dbPath).toBe('/new.db');
+  });
+});


### PR DESCRIPTION
## Summary

- Creates `src/services/store-factory.ts` with `createStoreSingleton<T>()` factory
- Wires all 7 store files to use the factory — eliminates inconsistency where 5 stores silently ignored a second call with a different `dbPath` while 2 threw correctly
- `tests/services/store-factory.test.ts` covers all factory behaviors (TDD: tests written before implementation)

## Changes

- `src/services/store-factory.ts` — NEW: `createStoreSingleton<T>()` factory + `StoreSingleton<T>` interface
- `tests/services/store-factory.test.ts` — NEW: 9 factory unit tests
- 7 store files — replace hand-rolled singleton boilerplate with factory call (public API unchanged)

## Behaviour after

Every store now:
- Returns the same instance on repeated calls with the same path
- Throws `Error` identifying the store name and both paths if called with a different path while initialized
- `close()` calls `store.close()` and clears state
- `_resetForTests()` available on the factory object (singletons are module-private; test teardown uses `closeXxx()`)

## Testing

- [x] TDD: `tests/services/store-factory.test.ts` written and failing first
- [x] 3368 tests pass (132 files), 0 regressions
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

## Closes

Closes #18