### PR TITLE
fix(loader): guard removePluginDatabase behind pluginDbAllocated flag

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -242,6 +242,7 @@ export async function registerPlugins(app: App, pluginsDir?: string): Promise<vo
       continue;
     }
 
+    let pluginDbAllocated = false;
     try {
       // SECURITY: Validate tools before any initialization
       if (plugin.tools && plugin.tools.length > 0) {
@@ -264,6 +265,7 @@ export async function registerPlugins(app: App, pluginsDir?: string): Promise<vo
 
       // Create plugin context with scoped database accessor
       const pluginDb = getPluginDatabase(plugin.name);
+      pluginDbAllocated = true;
 
       // Create PluginClaude if Claude is enabled
       const config = await getConfig();
@@ -402,8 +404,12 @@ export async function registerPlugins(app: App, pluginsDir?: string): Promise<vo
         toolCount: taggedTools.length,
       });
     } catch (error) {
-      // Clean up database accessor to prevent memory leak
-      removePluginDatabase(plugin.name);
+      // Only clean up the DB accessor if it was actually allocated; a failure
+      // before getPluginDatabase() (e.g. validatePluginTools throwing) means
+      // there is no entry to remove.
+      if (pluginDbAllocated) {
+        removePluginDatabase(plugin.name);
+      }
 
       logger.error('Failed to initialize plugin', {
         name: plugin.name,

--- a/tests/plugins/loader.test.ts
+++ b/tests/plugins/loader.test.ts
@@ -383,6 +383,7 @@ describe('plugin loader', () => {
 
       expect(getPluginDatabase).toHaveBeenCalledOnce();
       expect(removePluginDatabase).toHaveBeenCalledOnce();
+      expect(removePluginDatabase).toHaveBeenCalledWith('initfail');
     });
   });
 });

--- a/tests/plugins/loader.test.ts
+++ b/tests/plugins/loader.test.ts
@@ -26,10 +26,35 @@ vi.mock('../../src/commands/ask.js', () => ({
   checkAndRecordClaudeRequest: vi.fn().mockReturnValue(true),
 }));
 
+// Call-through spy wrappers — existing tests use the real implementations;
+// DB-cleanup tests override with mockImplementationOnce per-test.
+vi.mock('../../src/services/plugin-database.js', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const real = await importOriginal<typeof import('../../src/services/plugin-database.js')>();
+  return {
+    ...real,
+    getPluginDatabase: vi.fn().mockImplementation(real.getPluginDatabase),
+    removePluginDatabase: vi.fn().mockImplementation(real.removePluginDatabase),
+    closePluginDatabases: vi.fn().mockImplementation(real.closePluginDatabases),
+    getPluginDatabasePath: vi.fn().mockImplementation(real.getPluginDatabasePath),
+  };
+});
+
+vi.mock('../../src/services/tools/validation.js', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const real = await importOriginal<typeof import('../../src/services/tools/validation.js')>();
+  return {
+    ...real,
+    validatePluginTools: vi.fn().mockImplementation(real.validatePluginTools),
+  };
+});
+
 // Import after mocking
 const { discoverPlugins, getPluginTools, destroyPlugins, getLoadedPlugins, registerPlugins } =
   await import('../../src/plugins/loader.js');
 const { clearRegisteredCommands } = await import('../../src/plugins/plugin-app.js');
+const { getPluginDatabase, removePluginDatabase } = await import('../../src/services/plugin-database.js');
+const { validatePluginTools } = await import('../../src/services/tools/validation.js');
 
 const TEST_PLUGINS_DIR = resolve(process.cwd(), '.plugins-test-tmp');
 
@@ -319,5 +344,45 @@ describe('plugin loader', () => {
       // Plugin should not have loaded due to timeout
       expect(getLoadedPlugins()).toHaveLength(0);
     }, 15000); // Test timeout of 15s
+  });
+
+  describe('DB cleanup on failure paths', () => {
+    beforeEach(() => {
+      vi.mocked(getPluginDatabase).mockClear();
+      vi.mocked(removePluginDatabase).mockClear();
+      vi.mocked(validatePluginTools).mockClear();
+    });
+
+    it('does not call getPluginDatabase or removePluginDatabase when validatePluginTools throws', async () => {
+      vi.mocked(validatePluginTools).mockImplementationOnce(() => {
+        throw new Error('Validation crash');
+      });
+
+      await mkdir(TEST_PLUGINS_DIR);
+      await writeFile(
+        join(TEST_PLUGINS_DIR, 'validatefail.js'),
+        // toolName present so the code reaches validatePluginTools before getPluginDatabase
+        createValidPluginContent('validatefail', { toolName: 'test_tool' })
+      );
+
+      await registerPlugins(mockApp, TEST_PLUGINS_DIR);
+
+      expect(getPluginDatabase).not.toHaveBeenCalled();
+      expect(removePluginDatabase).not.toHaveBeenCalled();
+    });
+
+    it('calls removePluginDatabase exactly once when init() throws after DB allocation', async () => {
+      await mkdir(TEST_PLUGINS_DIR);
+      // Use a unique name so jiti does not return a cached import from a prior test
+      await writeFile(
+        join(TEST_PLUGINS_DIR, 'initfail.js'),
+        createValidPluginContent('initfail', { hasInit: true, throwInInit: true })
+      );
+
+      await registerPlugins(mockApp, TEST_PLUGINS_DIR);
+
+      expect(getPluginDatabase).toHaveBeenCalledOnce();
+      expect(removePluginDatabase).toHaveBeenCalledOnce();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `pluginDbAllocated` boolean to the plugin initialization loop; set to `true` immediately after `getPluginDatabase()` returns successfully
- Wraps the `removePluginDatabase()` cleanup call in the catch block with `if (pluginDbAllocated)` — avoids calling cleanup on a Map entry that was never created
- Extends `tests/plugins/loader.test.ts` with call-through spy wrappers and two new tests covering each failure path

## Bug

If `validatePluginTools()` threw an unexpected exception (crash, not a validation failure), the outer `catch` would call `removePluginDatabase(plugin.name)` even though `getPluginDatabase()` was never called. `Map.delete()` on a missing key is a no-op, so the bug was silent — but the unconditional cleanup was semantically wrong and could obscure the original error in environments where `removePluginDatabase` has side effects.

## Changes

- `src/plugins/loader.ts` — `pluginDbAllocated` flag + guarded `removePluginDatabase` call
- `tests/plugins/loader.test.ts` — call-through spies for `plugin-database.js` and `validation.js`; two new DB cleanup path tests

## Testing

- [x] TDD: new tests written and failing before fix applied
- [x] 3361 tests pass (131 files)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

## Closes

Closes #19