### PR TITLE
fix(context-loader): validate context directories at startup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import { destroyPlugins } from './plugins/index.js';
 import { logger } from './utils/logger.js';
 import { closeConversationStore, getConversationStore } from './services/conversation-store.js';
 import { closeUserStore, getUserStore, resolveUserStoreDbPath } from './services/user-store.js';
+import { validateContextDirectories } from './services/context-loader.js';
 import { evaluateAuthStartup } from './services/auth-startup.js';
 import { startBackupSchedule } from './services/db-backup.js';
 import { startWebServer, stopWebServer } from './web/index.js';
@@ -171,6 +172,15 @@ async function main(): Promise<void> {
         backupDir,
         retain: config.claude.dbBackupRetain,
       });
+    }
+
+    // Validate context directories at startup so operators see loud errors
+    // instead of silent no-ops (non-fatal — bot still starts with bad paths).
+    if (config.claude?.contextOptions && config.claude.contextOptions.length > 0) {
+      const contextErrors = await validateContextDirectories(config.claude.contextOptions);
+      for (const error of contextErrors) {
+        logger.error('Context directory validation failed at startup', { error });
+      }
     }
 
     // Start web server if enabled

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -227,3 +227,4 @@ export const ConfigSchema = z.object({
 
 export type Config = z.infer<typeof ConfigSchema>;
 export type WebConfig = z.infer<typeof WebConfigSchema>;
+export type ContextOption = z.infer<typeof ContextOptionSchema>;

--- a/src/services/context-loader.ts
+++ b/src/services/context-loader.ts
@@ -219,3 +219,46 @@ export function clearContextCache(): void {
 export function clearContextCacheForAlias(alias: string): void {
   contextCache.delete(alias);
 }
+
+export interface ContextOption {
+  alias: string;
+  path: string;
+}
+
+/**
+ * Validate all configured context directories at startup.
+ *
+ * Returns an array of human-readable error strings — one per bad option.
+ * Callers should log each at `error` level; this function itself does not log.
+ * Validation is always non-fatal: a non-empty return array does not stop the bot.
+ */
+export async function validateContextDirectories(options: ContextOption[]): Promise<string[]> {
+  const errors: string[] = [];
+
+  for (const option of options) {
+    const resolved = path.resolve(option.path);
+    try {
+      await fs.access(resolved);
+    } catch {
+      errors.push(
+        `Context alias '${option.alias}': path '${option.path}' does not exist or is not accessible`,
+      );
+      continue;
+    }
+
+    try {
+      const context = await loadContextFromDirectory(option.path);
+      if (!context.claudeMd && context.contextFiles.size === 0) {
+        errors.push(
+          `Context alias '${option.alias}': directory '${option.path}' contains no .md files`,
+        );
+      }
+    } catch (error) {
+      errors.push(
+        `Context alias '${option.alias}': failed to load '${option.path}' — ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return errors;
+}

--- a/src/services/context-loader.ts
+++ b/src/services/context-loader.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '../utils/logger.js';
+import type { ContextOption } from '../config/schema.js';
 
 /**
  * Follow symlinks and return the real path
@@ -220,10 +221,7 @@ export function clearContextCacheForAlias(alias: string): void {
   contextCache.delete(alias);
 }
 
-export interface ContextOption {
-  alias: string;
-  path: string;
-}
+export type { ContextOption };
 
 /**
  * Validate all configured context directories at startup.
@@ -250,7 +248,7 @@ export async function validateContextDirectories(options: ContextOption[]): Prom
       const context = await loadContextFromDirectory(option.path);
       if (!context.claudeMd && context.contextFiles.size === 0) {
         errors.push(
-          `Context alias '${option.alias}': directory '${option.path}' contains no .md files`,
+          `Context alias '${option.alias}': directory '${option.path}' contains no recognized context files (.md, .txt, .yaml, .yml, .json)`,
         );
       }
     } catch (error) {

--- a/tests/services/context-loader.test.ts
+++ b/tests/services/context-loader.test.ts
@@ -177,10 +177,11 @@ describe('context-loader', () => {
       expect(errors).toHaveLength(0);
     });
 
-    it('returns error for a nonexistent directory, including the path', async () => {
+    it('returns error for a nonexistent directory, including the alias and path', async () => {
       const missingPath = path.join(testDir, 'does-not-exist');
       const errors = await validateContextDirectories([{ alias: 'missing', path: missingPath }]);
       expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('missing');
       expect(errors[0]).toContain(missingPath);
     });
 

--- a/tests/services/context-loader.test.ts
+++ b/tests/services/context-loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { loadContextFromDirectory, getContext, clearContextCache } from '../../src/services/context-loader.js';
+import { loadContextFromDirectory, getContext, clearContextCache, validateContextDirectories } from '../../src/services/context-loader.js';
 
 describe('context-loader', () => {
   let testDir: string;
@@ -167,6 +167,39 @@ describe('context-loader', () => {
       // Should reload from disk
       const result2 = await getContext(testDir);
       expect(result2?.claudeMd).toBe('Modified content');
+    });
+  });
+
+  describe('validateContextDirectories', () => {
+    it('returns empty array for a valid directory with .md files', async () => {
+      await fs.writeFile(path.join(testDir, 'CLAUDE.md'), '# Context');
+      const errors = await validateContextDirectories([{ alias: 'test', path: testDir }]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('returns error for a nonexistent directory, including the path', async () => {
+      const missingPath = path.join(testDir, 'does-not-exist');
+      const errors = await validateContextDirectories([{ alias: 'missing', path: missingPath }]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain(missingPath);
+    });
+
+    it('returns error for a directory with no .md files, including the alias', async () => {
+      // testDir exists but has no CLAUDE.md and no .claude/context/ .md files
+      const errors = await validateContextDirectories([{ alias: 'empty', path: testDir }]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('empty');
+    });
+
+    it('returns errors only for bad paths when mixed with valid ones', async () => {
+      await fs.writeFile(path.join(testDir, 'CLAUDE.md'), '# Valid');
+      const missingPath = path.join(testDir, 'nonexistent');
+      const errors = await validateContextDirectories([
+        { alias: 'good', path: testDir },
+        { alias: 'bad', path: missingPath },
+      ]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain(missingPath);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `validateContextDirectories(options: ContextOption[])` to `src/services/context-loader.ts`
- Calls it in `main()` in `app.ts` after auth startup validation; each error logs at `error` level — non-fatal, bot starts regardless
- Exports `ContextOption` from `src/config/schema.ts` as single source of truth (re-exported from context-loader for callers)

## Changes

- `src/services/context-loader.ts` — new `validateContextDirectories()` function + re-export of `ContextOption`
- `src/config/schema.ts` — export `ContextOption` type
- `src/app.ts` — startup validation call before `registerCommands`
- `tests/services/context-loader.test.ts` — 4 new TDD tests: valid dir, nonexistent dir (alias + path in error), dir with no recognized context files, and mixed options

## Behavior after

When the bot starts with `CLAUDE_CONTEXT_DIRS` configured:
- A path that doesn't exist → `logger.error("Context directory validation failed at startup", { error: "Context alias 'X': path '/bad/path' does not exist..." })`
- A path with no recognized context files → `logger.error` with alias + path
- A valid path → no output

## Testing

- [x] TDD: 4 tests written and failing before implementation
- [x] 3376 tests pass (132 files)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

## Closes

Closes #22