### PR TITLE
fix(cli-provider): log raw tool-call block content on JSON parse failure

### DIFF
--- a/src/services/providers/cli-provider.ts
+++ b/src/services/providers/cli-provider.ts
@@ -418,6 +418,11 @@ ${JSON.stringify(tools, null, 2)}
         cleanedResponse = cleanedResponse.substring(0, blockStart) + cleanedResponse.substring(blockEnd);
         // Don't advance searchFrom — the splice shifted content backward
       } catch (e) {
+        logger.debug('Malformed tool_call JSON block — raw content for diagnosis', {
+          blockIndex: failedParseCount,
+          rawContent: jsonStr.length > 2000 ? `${jsonStr.substring(0, 2000)}… (truncated)` : jsonStr,
+          parseError: e instanceof Error ? e.message : String(e),
+        });
         failedParseCount++;
         logger.warn('Failed to parse tool call JSON from bracket-matched block', {
           error: e instanceof Error ? e.message : 'Unknown error',

--- a/tests/services/providers/cli-provider.test.ts
+++ b/tests/services/providers/cli-provider.test.ts
@@ -81,6 +81,10 @@ describe('CliProvider', () => {
   });
 
   describe('parseResponse', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
     function parseResponse(response: string) {
       const provider = new CliProvider(config);
       const parse = (provider as unknown as { parseResponse: (r: string) => { text: string; toolCallRequests: unknown[]; failedParseCount: number } }).parseResponse.bind(provider);
@@ -269,7 +273,6 @@ But I continue anyway.`;
     });
 
     it('should emit a debug log with raw content and error when tool_call JSON fails to parse', () => {
-      mockLogger.debug.mockClear();
       const malformedBlock = '{invalid json here}';
       const response = `\`\`\`tool_call\n${malformedBlock}\n\`\`\``;
 
@@ -277,8 +280,9 @@ But I continue anyway.`;
 
       expect(result.failedParseCount).toBe(1);
       expect(mockLogger.debug).toHaveBeenCalledOnce();
-      const [, debugArgs] = mockLogger.debug.mock.calls[0];
-      expect(JSON.stringify(debugArgs)).toContain(malformedBlock);
+      const [, debugArgs] = mockLogger.debug.mock.calls[0] as [string, Record<string, unknown>];
+      expect(debugArgs.rawContent).toContain(malformedBlock);
+      expect(typeof debugArgs.parseError).toBe('string');
     });
 
     it('should report failedParseCount of 0 for valid tool calls', () => {

--- a/tests/services/providers/cli-provider.test.ts
+++ b/tests/services/providers/cli-provider.test.ts
@@ -2,6 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CliProvider } from '../../../src/services/providers/cli-provider.js';
 import type { CliProviderConfig, UserConfig, ConversationMessage } from '../../../src/services/providers/types.js';
 
+// Mock logger to verify debug output on parse failures
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock('../../../src/utils/logger.js', () => ({ logger: mockLogger }));
+
 // Mock child_process.spawn for callCli tests
 const mockStdin = { write: vi.fn(), end: vi.fn() };
 const mockStdout = { on: vi.fn() };
@@ -257,6 +266,19 @@ But I continue anyway.`;
       const result = parseResponse(response);
       expect(result.toolCallRequests).toHaveLength(0);
       expect(result.failedParseCount).toBe(1);
+    });
+
+    it('should emit a debug log with raw content and error when tool_call JSON fails to parse', () => {
+      mockLogger.debug.mockClear();
+      const malformedBlock = '{invalid json here}';
+      const response = `\`\`\`tool_call\n${malformedBlock}\n\`\`\``;
+
+      const result = parseResponse(response);
+
+      expect(result.failedParseCount).toBe(1);
+      expect(mockLogger.debug).toHaveBeenCalledOnce();
+      const [, debugArgs] = mockLogger.debug.mock.calls[0];
+      expect(JSON.stringify(debugArgs)).toContain(malformedBlock);
     });
 
     it('should report failedParseCount of 0 for valid tool calls', () => {


### PR DESCRIPTION
## Summary

When `JSON.parse()` throws for a tool_call block in `parseResponse()`, the existing `logger.warn()` had no diagnostic content — operators couldn't reproduce or understand what Claude returned. This adds a `logger.debug()` before the warn with the raw block content (truncated to 2000 chars), block index, and parse error.

## Changes

- `src/services/providers/cli-provider.ts` — add `logger.debug()` in the JSON parse catch block
- `tests/services/providers/cli-provider.test.ts` — mock logger via `vi.hoisted()`, add test asserting debug call with raw content and error; add `beforeEach(vi.clearAllMocks)` to `parseResponse` describe

## Testing

- [x] TDD: test written and failing before implementation
- [x] 3373 tests pass (132 files)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

## Closes

Closes #23