### PR TITLE
refactor(web/routes): extract admin and dashboard route modules (2/2)

### DIFF
--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -81,6 +81,7 @@ export function createAdminRouter(dbPath: string, webConfig: WebConfig): Router 
     // Last-admin protection: count + update aren't atomic. The window between count
     // check and updateRole is a few SQLite ops; concurrent demotions could each see
     // count=2 and both proceed, leaving zero admins. Acceptable for home-server scale.
+    // Once #310 (manage-users CLI) merges, swap to the atomic `demoteIfNotLastAdmin`.
     if (user.role === 'admin' && newRole !== 'admin' && userStore.countByRole('admin') <= 1) {
       res.redirect(302, '/admin/users?error=' + encodeURIComponent('Refusing to demote the last admin.'));
       return;

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -1,0 +1,214 @@
+import express, { type Request, type Response, type NextFunction, type Router } from 'express';
+import type { WebConfig } from '../../config/schema.js';
+import { getUserStore } from '../../services/user-store.js';
+import { getInviteStore } from '../../services/invite-store.js';
+import { logger } from '../../utils/logger.js';
+import { renderAdminUsers, renderError } from '../templates/index.js';
+import { adminGuard } from '../middleware/auth.js';
+
+export function createAdminRouter(dbPath: string, webConfig: WebConfig): Router {
+  const router = express.Router();
+
+  // adminGuard lives in src/web/middleware/auth.ts and is applied here so
+  // this router is self-contained — callers only need to wire sessionAuthMiddleware.
+  router.use(adminGuard);
+
+  router.get('/users', (req: Request, res: Response) => {
+    try {
+      const userStore = getUserStore(dbPath);
+      const inviteStore = getInviteStore(dbPath);
+      const users = userStore.listAll();
+      const invites = inviteStore.listActive();
+      // Flash/error round-trip through the redirect URL (stateless — no flash store needed).
+      const flash = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+      const errMsg = typeof req.query.error === 'string' ? req.query.error : undefined;
+      res.type('html').send(
+        renderAdminUsers({
+          users,
+          invites,
+          baseUrl: webConfig.baseUrl,
+          flash,
+          error: errMsg,
+        }),
+      );
+    } catch (err) {
+      logger.error('Error rendering /admin/users', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      res.status(500).type('html').send(renderError('Failed to load admin page.'));
+    }
+  });
+
+  router.post('/users', (req: Request, res: Response, next: NextFunction) => {
+    (async () => {
+      const body = req.body as Record<string, string>;
+      const slackId = (body.slack_id ?? '').trim();
+      const displayName = (body.display_name ?? '').trim() || undefined;
+      const role = body.role === 'admin' ? 'admin' : 'user';
+      if (!/^U[A-Z0-9]+$/.test(slackId)) {
+        res.redirect(302, '/admin/users?error=' + encodeURIComponent('Slack ID must look like U01ABC...'));
+        return;
+      }
+      const userStore = getUserStore(dbPath);
+      if (userStore.getBySlackId(slackId)) {
+        res.redirect(302, '/admin/users?error=' + encodeURIComponent('User already exists.'));
+        return;
+      }
+      await userStore.create({ slackId, role, displayName });
+      logger.info('Admin created user via web', {
+        actor: res.locals.userId as string,
+        slackId,
+        role,
+      });
+      res.redirect(302, '/admin/users?flash=' + encodeURIComponent(`Added ${slackId}.`));
+    })().catch(next);
+  });
+
+  router.post('/users/:id/role', (req: Request, res: Response) => {
+    const id = parseInt(typeof req.params.id === 'string' ? req.params.id : '', 10);
+    const body = req.body as Record<string, string>;
+    const newRole = body.role === 'admin' ? 'admin' : 'user';
+    if (!Number.isInteger(id)) {
+      res.redirect(302, '/admin/users?error=Invalid+user+id');
+      return;
+    }
+    const userStore = getUserStore(dbPath);
+    const user = userStore.getById(id);
+    if (!user) {
+      res.redirect(302, '/admin/users?error=User+not+found');
+      return;
+    }
+    // Last-admin protection: count + update aren't atomic. The window between count
+    // check and updateRole is a few SQLite ops; concurrent demotions could each see
+    // count=2 and both proceed, leaving zero admins. Acceptable for home-server scale.
+    if (user.role === 'admin' && newRole !== 'admin' && userStore.countByRole('admin') <= 1) {
+      res.redirect(302, '/admin/users?error=' + encodeURIComponent('Refusing to demote the last admin.'));
+      return;
+    }
+    userStore.updateRole(id, newRole);
+    logger.info('Admin changed user role', {
+      actor: res.locals.userId as string,
+      targetId: id,
+      newRole,
+    });
+    res.redirect(302, '/admin/users?flash=Role+updated');
+  });
+
+  router.post('/users/:id/toggle-active', (req: Request, res: Response) => {
+    const id = parseInt(typeof req.params.id === 'string' ? req.params.id : '', 10);
+    if (!Number.isInteger(id)) {
+      res.redirect(302, '/admin/users?error=Invalid+user+id');
+      return;
+    }
+    const userStore = getUserStore(dbPath);
+    const user = userStore.getById(id);
+    if (!user) {
+      res.redirect(302, '/admin/users?error=User+not+found');
+      return;
+    }
+    if (user.isActive && user.role === 'admin' && userStore.countByRole('admin') <= 1) {
+      res.redirect(302, '/admin/users?error=' + encodeURIComponent('Refusing to deactivate the last admin.'));
+      return;
+    }
+    if (user.isActive) userStore.deactivate(id); else userStore.activate(id);
+    logger.info('Admin toggled user active', {
+      actor: res.locals.userId as string,
+      targetId: id,
+      newState: !user.isActive,
+    });
+    res.redirect(302, '/admin/users?flash=' + encodeURIComponent(user.isActive ? 'User deactivated.' : 'User activated.'));
+  });
+
+  router.post('/users/:id/reset-password', (req: Request, res: Response, next: NextFunction) => {
+    (async () => {
+      const id = parseInt(typeof req.params.id === 'string' ? req.params.id : '', 10);
+      const body = req.body as Record<string, unknown>;
+      const newPassword = typeof body.password === 'string' ? body.password : '';
+      if (!Number.isInteger(id)) {
+        res.redirect(302, '/admin/users?error=Invalid+user+id');
+        return;
+      }
+      if (newPassword.length < 8) {
+        res.redirect(302, '/admin/users?error=' + encodeURIComponent('Password must be at least 8 characters.'));
+        return;
+      }
+      const userStore = getUserStore(dbPath);
+      const user = userStore.getById(id);
+      if (!user) {
+        res.redirect(302, '/admin/users?error=User+not+found');
+        return;
+      }
+      await userStore.updatePassword(id, newPassword);
+      logger.info('Admin reset user password', {
+        actor: res.locals.userId as string,
+        targetId: id,
+      });
+      res.redirect(302, '/admin/users?flash=Password+updated.');
+    })().catch(next);
+  });
+
+  router.post('/invites', (req: Request, res: Response) => {
+    const body = req.body as Record<string, string>;
+    const role = body.role === 'admin' ? 'admin' : 'user';
+    const ttlHoursRaw = parseInt(body.ttl_hours ?? '72', 10);
+    const ttlHours =
+      Number.isInteger(ttlHoursRaw) && ttlHoursRaw > 0 ? Math.min(ttlHoursRaw, 24 * 365) : 72;
+    const slackUserIdRaw = (body.slack_user_id ?? '').trim();
+    const slackUserId = slackUserIdRaw || undefined;
+    if (slackUserId && !/^U[A-Z0-9]+$/.test(slackUserId)) {
+      res.redirect(
+        302,
+        '/admin/users?error=' +
+          encodeURIComponent('Pre-link Slack ID must look like U01ABC...'),
+      );
+      return;
+    }
+
+    // Resolve the requesting admin's user-row id for invite_codes.created_by.
+    //
+    // Three session shapes:
+    //   - 'admin'      → static emergency-token; no user row exists. Use 0 as sentinel.
+    //   - 'web:<user>' → look up by username.
+    //   - 'U...'       → look up by Slack ID.
+    const userStore = getUserStore(dbPath);
+    const sessionUserId = res.locals.userId as string;
+    let createdByUserId: number;
+    if (sessionUserId === 'admin') {
+      createdByUserId = 0;
+    } else {
+      const requester = sessionUserId.startsWith('web:')
+        ? userStore.getByUsername(sessionUserId.slice(4))
+        : userStore.getBySlackId(sessionUserId);
+      if (!requester) {
+        res.redirect(
+          302,
+          '/admin/users?error=' +
+            encodeURIComponent(
+              'Your account is not in the users table. Run `npm run manage-users create-user` first.',
+            ),
+        );
+        return;
+      }
+      createdByUserId = requester.id;
+    }
+
+    const inviteStore = getInviteStore(dbPath);
+    inviteStore.createInvite(createdByUserId, { role, ttlHours, slackUserId });
+    logger.info('Admin created invite via web', { actor: sessionUserId, role, ttlHours });
+    res.redirect(302, '/admin/users?flash=Invite+created.');
+  });
+
+  router.post('/invites/:code/delete', (req: Request, res: Response) => {
+    const code = typeof req.params.code === 'string' ? req.params.code : '';
+    if (!/^[0-9a-f]{32}$/.test(code)) {
+      res.redirect(302, '/admin/users?error=Invalid+code');
+      return;
+    }
+    const inviteStore = getInviteStore(dbPath);
+    inviteStore.deleteInvite(code);
+    logger.info('Admin deleted invite', { actor: res.locals.userId as string, code });
+    res.redirect(302, '/admin/users?flash=Invite+deleted.');
+  });
+
+  return router;
+}

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -1,7 +1,5 @@
 import express, { type Request, type Response, type NextFunction, type Router } from 'express';
 import type { Config, WebConfig } from '../../config/schema.js';
-
-type ClaudeConfig = NonNullable<Config['claude']>;
 import { getSocketModeStatus } from '../../services/socket-mode-status.js';
 import { getConversationStore } from '../../services/conversation-store.js';
 import { getSessionStore } from '../../services/session-store.js';
@@ -29,6 +27,8 @@ import {
   getUserFilterIds,
 } from '../middleware/auth.js';
 import { attachTags } from './helpers.js';
+
+type ClaudeConfig = NonNullable<Config['claude']>;
 
 export function createDashboardRouter(
   claudeConfig: ClaudeConfig,

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -1,0 +1,377 @@
+import express, { type Request, type Response, type NextFunction, type Router } from 'express';
+import type { Config, WebConfig } from '../../config/schema.js';
+
+type ClaudeConfig = NonNullable<Config['claude']>;
+import { getSocketModeStatus } from '../../services/socket-mode-status.js';
+import { getConversationStore } from '../../services/conversation-store.js';
+import { getSessionStore } from '../../services/session-store.js';
+import { getUserStore } from '../../services/user-store.js';
+import { getInviteStore } from '../../services/invite-store.js';
+import { isAuthHitAllowed, recordAuthFailure } from '../../services/auth-rate-limit.js';
+import { resolveTokenWithRole, resolveUserPassword, parseCookies, createLinkToken } from '../auth.js';
+import { getNotificationStore } from '../../services/notification-store.js';
+import { getQuickLinksStore } from '../../services/quick-links-store.js';
+import { getServerHealth } from '../../services/server-health.js';
+import { getPluginWidgets } from '../../plugins/loader.js';
+import { logger } from '../../utils/logger.js';
+import {
+  renderDashboard,
+  renderLogin,
+  renderRegister,
+  renderError,
+  render404,
+} from '../templates/index.js';
+import { getStaticCss } from '../templates/styles.js';
+import {
+  SESSION_COOKIE,
+  buildCookieOptions,
+  optionalAuthMiddleware,
+  getUserFilterIds,
+} from '../middleware/auth.js';
+import { attachTags } from './helpers.js';
+
+export function createDashboardRouter(
+  claudeConfig: ClaudeConfig,
+  webConfig: WebConfig,
+  dbPath: string,
+): Router {
+  const router = express.Router();
+
+  // Health check (no auth required). Returns 200 when Socket Mode is connected,
+  // 503 when disconnected. Used by Docker HEALTHCHECK.
+  router.get('/health', (_req: Request, res: Response) => {
+    const socketMode = getSocketModeStatus();
+    const status = socketMode.connected ? 'ok' : 'degraded';
+    const statusCode = socketMode.connected ? 200 : 503;
+    res.status(statusCode).json({ status, socketMode });
+  });
+
+  // PWA manifest (no auth, cacheable)
+  router.get('/manifest.json', (_req: Request, res: Response) => {
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.json({
+      name: 'Server Monitor',
+      short_name: 'SSM',
+      description: 'AI-powered server diagnostics',
+      start_url: '/',
+      display: 'standalone',
+      background_color: '#282a36',
+      theme_color: '#282a36',
+      icons: [
+        {
+          src:
+            'data:image/svg+xml,' +
+            encodeURIComponent(
+              '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="#ff79c6" stroke-width="1.5"><rect x="4" y="6" width="12" height="10" rx="2"/><circle cx="7.5" cy="11" r="1.5"/><circle cx="12.5" cy="11" r="1.5"/><path d="M10 2v4M6 6V4M14 6V4"/></svg>',
+            ),
+          sizes: 'any',
+          type: 'image/svg+xml',
+        },
+      ],
+    });
+  });
+
+  // Static CSS bundle (no auth, aggressively cached)
+  router.get('/static/styles.css', (_req: Request, res: Response) => {
+    res.setHeader('Content-Type', 'text/css; charset=utf-8');
+    res.setHeader('Cache-Control', 'public, max-age=86400');
+    res.send(getStaticCss());
+  });
+
+  // Login page
+  router.get('/login', (req: Request, res: Response) => {
+    const returnTo = typeof req.query.return_to === 'string' ? req.query.return_to : undefined;
+    res.type('html').send(renderLogin(undefined, returnTo, webConfig.registrationEnabled));
+  });
+
+  // Login form submission. Accepts either:
+  //   - `username` + `password`  → resolveUserPassword (web account flow)
+  //   - `token`                  → resolveTokenWithRole (HMAC link / static admin)
+  // If both are sent, username/password takes precedence.
+  router.post('/login', (req: Request, res: Response, next: NextFunction) => {
+    (async () => {
+      const body = req.body as Record<string, unknown>;
+      const username = typeof body.username === 'string' ? body.username.trim() : '';
+      const password = typeof body.password === 'string' ? body.password : '';
+      const token = typeof body.token === 'string' ? body.token : '';
+      const returnTo = typeof body.return_to === 'string' ? body.return_to : undefined;
+      const ip = req.ip ?? '0.0.0.0';
+
+      if (!isAuthHitAllowed('login', ip)) {
+        logger.warn('Login rate-limited', { ip });
+        res
+          .status(429)
+          .type('html')
+          .send(
+            renderLogin(
+              'Too many attempts. Try again in a few minutes.',
+              returnTo,
+              webConfig.registrationEnabled,
+            ),
+          );
+        return;
+      }
+
+      const userStore = getUserStore(dbPath);
+      let identity: { userId: string; isAdmin: boolean } | null = null;
+      if (username && password) {
+        identity = await resolveUserPassword(username, password, userStore);
+      } else if (token) {
+        identity = await resolveTokenWithRole(token, webConfig, userStore);
+      }
+
+      if (!identity) {
+        recordAuthFailure('login', ip);
+        logger.warn('Failed login attempt', {
+          ip,
+          hasUsername: Boolean(username),
+          hasToken: Boolean(token),
+        });
+        res
+          .status(401)
+          .type('html')
+          .send(renderLogin('Invalid credentials.', returnTo, webConfig.registrationEnabled));
+        return;
+      }
+
+      const sessionStore = getSessionStore(dbPath, webConfig.sessionTtlHours);
+      sessionStore.deleteSessionsForUser(identity.userId);
+      const session = sessionStore.createSession(identity.userId, identity.isAdmin);
+      const maxAge = webConfig.sessionTtlHours * 60 * 60;
+      res.setHeader(
+        'Set-Cookie',
+        `${SESSION_COOKIE}=${session.sessionId}; ${buildCookieOptions(webConfig, maxAge)}`,
+      );
+
+      logger.info('User logged in via form', {
+        userId: identity.userId,
+        isAdmin: identity.isAdmin,
+      });
+
+      // Only allow same-origin redirect paths: must start with `/` but NOT `//`
+      // (protocol-relative → external host) or `/\` (Windows-path coercion).
+      const redirectTo =
+        returnTo &&
+        returnTo.startsWith('/') &&
+        !returnTo.startsWith('//') &&
+        !returnTo.startsWith('/\\')
+          ? returnTo
+          : '/';
+      res.redirect(302, redirectTo);
+    })().catch(next);
+  });
+
+  // Registration page — 404 when disabled to avoid leaking route existence.
+  router.get('/register', (req: Request, res: Response) => {
+    if (!webConfig.registrationEnabled) {
+      res.status(404).send(render404());
+      return;
+    }
+    const inviteCode = typeof req.query.invite === 'string' ? req.query.invite : undefined;
+    res.type('html').send(renderRegister(undefined, { inviteCode }));
+  });
+
+  // Registration form submission.
+  router.post('/register', (req: Request, res: Response, next: NextFunction) => {
+    if (!webConfig.registrationEnabled) {
+      res.status(404).send(render404());
+      return;
+    }
+    (async () => {
+      const body = req.body as Record<string, unknown>;
+      const inviteCode = typeof body.invite === 'string' ? body.invite.trim() : '';
+      const username = typeof body.username === 'string' ? body.username.trim() : '';
+      const password = typeof body.password === 'string' ? body.password : '';
+      const confirm = typeof body.confirm_password === 'string' ? body.confirm_password : '';
+      const ip = req.ip ?? '0.0.0.0';
+
+      const reject = (status: number, message: string): void => {
+        res.status(status).type('html').send(renderRegister(message, { inviteCode, username }));
+      };
+
+      if (!isAuthHitAllowed('register', ip)) {
+        logger.warn('Register rate-limited', { ip });
+        reject(429, 'Too many attempts. Try again in a few minutes.');
+        return;
+      }
+
+      if (!inviteCode || !username || !password) {
+        recordAuthFailure('register', ip);
+        reject(400, 'All fields are required.');
+        return;
+      }
+      if (password !== confirm) {
+        recordAuthFailure('register', ip);
+        reject(400, 'Passwords do not match.');
+        return;
+      }
+      if (password.length < 8) {
+        recordAuthFailure('register', ip);
+        reject(400, 'Password must be at least 8 characters.');
+        return;
+      }
+
+      const userStore = getUserStore(dbPath);
+      const inviteStore = getInviteStore(dbPath);
+
+      // Pre-flight: peek invite before expensive work. Atomicity comes from
+      // redeemInvite below; we peek here for a friendly error on the common cases.
+      const peek = inviteStore.getInvite(inviteCode);
+      if (!peek) {
+        recordAuthFailure('register', ip);
+        logger.warn('Register attempted with unknown invite', { ip });
+        reject(400, 'Invite code is invalid, expired, or already used.');
+        return;
+      }
+      if (peek.usedAt !== null || peek.expiresAt <= Date.now()) {
+        recordAuthFailure('register', ip);
+        logger.warn('Register attempted with used or expired invite', { ip });
+        reject(400, 'Invite code is invalid, expired, or already used.');
+        return;
+      }
+
+      // Atomicity note: create user → redeem invite is not transactional across
+      // two stores. If the process crashes between steps, a stranded user row exists.
+      // Recovery: admin removes via `npm run manage-users delete-user`. Acceptable
+      // for home-server deployment.
+      let user;
+      try {
+        user = await userStore.create({
+          username,
+          password,
+          slackId: peek.slackUserId ?? undefined,
+          role: peek.role,
+        });
+      } catch (err) {
+        recordAuthFailure('register', ip);
+        logger.warn('Register validation failed', {
+          ip,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        reject(400, 'Username or password did not pass validation.');
+        return;
+      }
+
+      // Atomic redeem — lose the race → roll back the created user so the invite
+      // isn't burned and the username isn't squatted.
+      const redeemed = inviteStore.redeemInvite(inviteCode, user.id);
+      if (!redeemed) {
+        userStore.deleteById(user.id);
+        recordAuthFailure('register', ip);
+        logger.warn('Lost invite redeem race; rolled back created user', {
+          ip,
+          userId: user.id,
+        });
+        reject(400, 'Invite code was just consumed. Please request a new one.');
+        return;
+      }
+
+      if (!user.username) {
+        userStore.deleteById(user.id);
+        logger.error('User created without a canonical username — rolled back', {
+          ip,
+          userId: user.id,
+        });
+        reject(400, 'Could not create account.');
+        return;
+      }
+      const identityUserId = `web:${user.username}`;
+      const sessionStore = getSessionStore(dbPath, webConfig.sessionTtlHours);
+      sessionStore.deleteSessionsForUser(identityUserId);
+      const session = sessionStore.createSession(identityUserId, user.role === 'admin');
+      const maxAge = webConfig.sessionTtlHours * 60 * 60;
+      res.setHeader(
+        'Set-Cookie',
+        `${SESSION_COOKIE}=${session.sessionId}; ${buildCookieOptions(webConfig, maxAge)}`,
+      );
+
+      logger.info('User registered via invite', { userId: identityUserId, role: user.role });
+      res.redirect(302, '/');
+    })().catch(next);
+  });
+
+  // Logout
+  router.post('/logout', (req: Request, res: Response) => {
+    const cookies = parseCookies(req.headers.cookie);
+    const sessionId = cookies[SESSION_COOKIE];
+    if (sessionId) {
+      const sessionStore = getSessionStore(dbPath, webConfig.sessionTtlHours);
+      sessionStore.deleteSession(sessionId);
+    }
+    res.setHeader('Set-Cookie', `${SESSION_COOKIE}=; ${buildCookieOptions(webConfig, 0)}`);
+    res.redirect(302, '/login');
+  });
+
+  // Dashboard home (optional auth — public with reduced view)
+  router.get('/', optionalAuthMiddleware(webConfig, dbPath), async (_req: Request, res: Response) => {
+    try {
+      const isAuthenticated = !!res.locals.userId;
+      const userId = (res.locals.userId as string) || 'anonymous';
+      const health = await getServerHealth();
+
+      const store = getConversationStore(claudeConfig.dbPath, claudeConfig.conversationTtlHours);
+      const filterIds = isAuthenticated ? getUserFilterIds(res, dbPath) : undefined;
+      const stats = isAuthenticated
+        ? store.getSessionStats(24, filterIds)
+        : {
+            totalSessions: 0,
+            activeSessions: 0,
+            totalMessages: 0,
+            totalToolCalls: 0,
+            avgToolDurationMs: null,
+            toolFailureRate: 0,
+            topTools: [] as { name: string; count: number; avgDurationMs: number | null }[],
+          };
+      const recent = isAuthenticated ? store.listRecentSessions(5, 0, filterIds) : [];
+      if (isAuthenticated) attachTags(recent, store);
+      const favorites = isAuthenticated ? store.listFavoriteSessions(3, 0, filterIds) : [];
+      const favCount = isAuthenticated ? store.countFavoriteSessions(filterIds) : 0;
+      const allTags = isAuthenticated ? store.listAllTags(filterIds) : [];
+      const widgets = getPluginWidgets(!isAuthenticated);
+      const notifStore = getNotificationStore(claudeConfig.dbPath);
+      const unreadCount = isAuthenticated ? notifStore.countUnread() : 0;
+      const linksStore = getQuickLinksStore(claudeConfig.dbPath);
+      const userLinks = isAuthenticated ? linksStore.getLinks(userId) : [];
+
+      const html = renderDashboard(
+        stats,
+        recent,
+        favorites,
+        favCount,
+        allTags,
+        userId,
+        widgets,
+        unreadCount,
+        userLinks,
+        health,
+        isAuthenticated,
+      );
+      res.type('html').send(html);
+    } catch (err) {
+      logger.error('Error serving dashboard', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      res.status(500).send(renderError('Failed to load dashboard.'));
+    }
+  });
+
+  return router;
+}
+
+/**
+ * Generate a web URL for a conversation (HMAC-signed, time-limited link token).
+ */
+export function getConversationUrl(
+  threadTs: string,
+  channelId: string,
+  webConfig: WebConfig,
+  userId?: string,
+): string {
+  const baseUrl = webConfig.baseUrl ?? `http://localhost:${String(webConfig.port)}`;
+  const token = createLinkToken(
+    userId ?? 'system',
+    webConfig.authToken,
+    webConfig.linkTokenTtlMinutes,
+  );
+  return `${baseUrl}/c/${threadTs}/${channelId}?token=${encodeURIComponent(token)}`;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -15,34 +15,24 @@
 import express, { type Request, type Response, type NextFunction } from 'express';
 import type { Server } from 'http';
 import { config, type WebConfig } from '../config/index.js';
-import { getSocketModeStatus } from '../services/socket-mode-status.js';
-import { getConversationStore } from '../services/conversation-store.js';
 import { getSessionStore, closeSessionStore } from '../services/session-store.js';
-import { getUserStore } from '../services/user-store.js';
-import { getInviteStore } from '../services/invite-store.js';
-import { isAuthHitAllowed, recordAuthFailure } from '../services/auth-rate-limit.js';
-import { resolveTokenWithRole, resolveUserPassword, parseCookies, createLinkToken } from './auth.js';
 import { SSEConnectionManager, setSharedSSEManager } from './sse.js';
 import { resetEventBus } from '../services/event-bus.js';
 import { logger } from '../utils/logger.js';
-import { renderDashboard, render404, renderLogin, renderError, renderRegister, renderAdminUsers } from './templates/index.js';
-import { getStaticCss } from './templates/styles.js';
-import { getPluginWidgets } from '../plugins/loader.js';
+import { render404 } from './templates/index.js';
 import { getPluginExpressRouter, isPluginPublic } from './plugin-router.js';
 import { getNotificationStore, closeNotificationStore } from '../services/notification-store.js';
-import { getQuickLinksStore, closeQuickLinksStore } from '../services/quick-links-store.js';
-import { getServerHealth } from '../services/server-health.js';
+import { closeQuickLinksStore } from '../services/quick-links-store.js';
 import {
-  SESSION_COOKIE,
-  buildCookieOptions,
   sessionAuthMiddleware,
   optionalAuthMiddleware,
-  adminGuard,
-  getUserFilterIds,
 } from './middleware/auth.js';
-import { attachTags } from './routes/helpers.js';
 import { createConversationsRouter } from './routes/conversations.js';
 import { createApiRouter } from './routes/api.js';
+import { createAdminRouter } from './routes/admin.js';
+import { createDashboardRouter } from './routes/dashboard.js';
+
+export { getConversationUrl } from './routes/dashboard.js';
 
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -68,23 +58,27 @@ export async function startWebServer(webConfig: WebConfig): Promise<void> {
   sseManager = new SSEConnectionManager();
   setSharedSSEManager(sseManager);
 
-  // Parse request bodies
   app.use(express.urlencoded({ extended: false }));
   app.use(express.json());
 
-  // Request timing — logs slow requests (all response types) and adds X-Response-Time header (send paths only)
+  // Request timing — logs slow requests and adds X-Response-Time header (send paths only)
   app.use((req: Request, res: Response, next: NextFunction) => {
     const start = Date.now();
 
-    // 'finish' fires for all response types: send, json, redirect, SSE end — comprehensive coverage
+    // 'finish' fires for all response types: send, json, redirect, SSE end
     res.on('finish', () => {
       const duration = Date.now() - start;
       if (duration > 500) {
-        logger.warn('Slow request', { method: req.method, path: req.path, status: res.statusCode, durationMs: duration });
+        logger.warn('Slow request', {
+          method: req.method,
+          path: req.path,
+          status: res.statusCode,
+          durationMs: duration,
+        });
       }
     });
 
-    // X-Response-Time header on res.send() paths (normal routes, API endpoints) for DevTools visibility
+    // X-Response-Time on res.send() paths for DevTools visibility
     const originalSend = res.send.bind(res);
     res.send = function (body: Parameters<typeof res.send>[0]) {
       res.setHeader('X-Response-Time', String(Date.now() - start) + 'ms');
@@ -104,478 +98,16 @@ export async function startWebServer(webConfig: WebConfig): Promise<void> {
     next();
   });
 
-  // Health check endpoint (no auth required)
-  // Returns 200 when Socket Mode is connected, 503 when disconnected.
-  // Used by Docker HEALTHCHECK to detect stale WebSocket connections.
-  app.get('/health', (_req: Request, res: Response) => {
-    const socketMode = getSocketModeStatus();
-    const status = socketMode.connected ? 'ok' : 'degraded';
-    const statusCode = socketMode.connected ? 200 : 503;
-    res.status(statusCode).json({ status, socketMode });
-  });
-
-  // PWA manifest (no auth required, cacheable)
-  app.get('/manifest.json', (_req: Request, res: Response) => {
-    res.setHeader('Cache-Control', 'public, max-age=3600');
-    res.json({
-      name: 'Server Monitor',
-      short_name: 'SSM',
-      description: 'AI-powered server diagnostics',
-      start_url: '/',
-      display: 'standalone',
-      background_color: '#282a36',
-      theme_color: '#282a36',
-      icons: [
-        {
-          src: 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="#ff79c6" stroke-width="1.5"><rect x="4" y="6" width="12" height="10" rx="2"/><circle cx="7.5" cy="11" r="1.5"/><circle cx="12.5" cy="11" r="1.5"/><path d="M10 2v4M6 6V4M14 6V4"/></svg>'),
-          sizes: 'any',
-          type: 'image/svg+xml',
-        },
-      ],
-    });
-  });
-
-  // Static CSS bundle (no auth, aggressively cached)
-  app.get('/static/styles.css', (_req: Request, res: Response) => {
-    res.setHeader('Content-Type', 'text/css; charset=utf-8');
-    res.setHeader('Cache-Control', 'public, max-age=86400');
-    res.send(getStaticCss());
-  });
-
-  // Login page (no auth required)
-  app.get('/login', (req: Request, res: Response) => {
-    const returnTo = typeof req.query.return_to === 'string' ? req.query.return_to : undefined;
-    res.type('html').send(renderLogin(undefined, returnTo, webConfig.registrationEnabled));
-  });
-
-  // Login form submission. Accepts either:
-  //   - `username` + `password`  → resolveUserPassword (web account flow)
-  //   - `token`                  → resolveTokenWithRole (HMAC link / static admin)
-  // If both are sent, username/password takes precedence (explicit credentials
-  // beat a stale token in the form).
-  app.post('/login', (req: Request, res: Response, next: NextFunction) => {
-    (async () => {
-      const body = req.body as Record<string, unknown>;
-      const username = typeof body.username === 'string' ? body.username.trim() : '';
-      const password = typeof body.password === 'string' ? body.password : '';
-      const token = typeof body.token === 'string' ? body.token : '';
-      const returnTo = typeof body.return_to === 'string' ? body.return_to : undefined;
-      const ip = req.ip ?? '0.0.0.0';
-
-      // Peek the rate limit before doing any expensive work (scrypt verify).
-      // We only record a failure below — successful logins don't consume budget,
-      // so a legitimate user who logs in 5 times rapidly isn't locked out.
-      if (!isAuthHitAllowed('login', ip)) {
-        logger.warn('Login rate-limited', { ip });
-        res.status(429).type('html').send(renderLogin('Too many attempts. Try again in a few minutes.', returnTo, webConfig.registrationEnabled));
-        return;
-      }
-
-      const userStore = getUserStore(dbPath);
-      let identity: { userId: string; isAdmin: boolean } | null = null;
-      if (username && password) {
-        identity = await resolveUserPassword(username, password, userStore);
-      } else if (token) {
-        identity = await resolveTokenWithRole(token, webConfig, userStore);
-      }
-
-      if (!identity) {
-        recordAuthFailure('login', ip);
-        logger.warn('Failed login attempt', { ip, hasUsername: Boolean(username), hasToken: Boolean(token) });
-        res.status(401).type('html').send(renderLogin('Invalid credentials.', returnTo, webConfig.registrationEnabled));
-        return;
-      }
-
-      // Invalidate existing sessions for this user, then create a new one
-      const sessionStore = getSessionStore(dbPath, webConfig.sessionTtlHours);
-      sessionStore.deleteSessionsForUser(identity.userId);
-      const session = sessionStore.createSession(identity.userId, identity.isAdmin);
-      const maxAge = webConfig.sessionTtlHours * 60 * 60;
-      res.setHeader('Set-Cookie', `${SESSION_COOKIE}=${session.sessionId}; ${buildCookieOptions(webConfig, maxAge)}`);
-
-      logger.info('User logged in via form', { userId: identity.userId, isAdmin: identity.isAdmin });
-
-      // Redirect to return_to or home. Allow only same-origin paths:
-      // must start with `/` but NOT `//` (which would be a
-      // protocol-relative URL → external host) or `/\` (a Windows-path
-      // shape some browsers also coerce). Falls back to `/` for
-      // anything else, including the empty string.
-      const redirectTo =
-        returnTo && returnTo.startsWith('/') && !returnTo.startsWith('//') && !returnTo.startsWith('/\\')
-          ? returnTo
-          : '/';
-      res.redirect(302, redirectTo);
-    })().catch(next);
-  });
-
-  // Registration page. Returns 404 when registration is disabled — no leak
-  // about whether the route exists.
-  app.get('/register', (req: Request, res: Response) => {
-    if (!webConfig.registrationEnabled) {
-      res.status(404).send(render404());
-      return;
-    }
-    const inviteCode = typeof req.query.invite === 'string' ? req.query.invite : undefined;
-    res.type('html').send(renderRegister(undefined, { inviteCode }));
-  });
-
-  // Registration form submission.
-  app.post('/register', (req: Request, res: Response, next: NextFunction) => {
-    if (!webConfig.registrationEnabled) {
-      res.status(404).send(render404());
-      return;
-    }
-    (async () => {
-      const body = req.body as Record<string, unknown>;
-      const inviteCode = typeof body.invite === 'string' ? body.invite.trim() : '';
-      const username = typeof body.username === 'string' ? body.username.trim() : '';
-      const password = typeof body.password === 'string' ? body.password : '';
-      const confirm = typeof body.confirm_password === 'string' ? body.confirm_password : '';
-      const ip = req.ip ?? '0.0.0.0';
-
-      const reject = (status: number, message: string): void => {
-        res.status(status).type('html').send(renderRegister(message, { inviteCode, username }));
-      };
-
-      if (!isAuthHitAllowed('register', ip)) {
-        logger.warn('Register rate-limited', { ip });
-        reject(429, 'Too many attempts. Try again in a few minutes.');
-        return;
-      }
-
-      if (!inviteCode || !username || !password) {
-        recordAuthFailure('register', ip);
-        reject(400, 'All fields are required.');
-        return;
-      }
-      if (password !== confirm) {
-        recordAuthFailure('register', ip);
-        reject(400, 'Passwords do not match.');
-        return;
-      }
-      if (password.length < 8) {
-        recordAuthFailure('register', ip);
-        reject(400, 'Password must be at least 8 characters.');
-        return;
-      }
-
-      const userStore = getUserStore(dbPath);
-      const inviteStore = getInviteStore(dbPath);
-
-      // Pre-flight: check the invite is currently valid. Atomicity comes
-      // from `redeemInvite` later; we peek here to give a friendly error
-      // for the common bad-code / expired-code cases. The expiry check
-      // mirrors `redeemInvite`'s `expires_at > ?` predicate exactly so a
-      // future change to the peek doesn't drift from the atomic redeem.
-      const peek = inviteStore.getInvite(inviteCode);
-      if (!peek) {
-        recordAuthFailure('register', ip);
-        logger.warn('Register attempted with unknown invite', { ip });
-        reject(400, 'Invite code is invalid, expired, or already used.');
-        return;
-      }
-      if (peek.usedAt !== null || peek.expiresAt <= Date.now()) {
-        recordAuthFailure('register', ip);
-        logger.warn('Register attempted with used or expired invite', { ip });
-        reject(400, 'Invite code is invalid, expired, or already used.');
-        return;
-      }
-
-      // Atomicity note: this sequence (create user → redeem invite) is
-      // not transactional across the two stores. If the process crashes
-      // between the two steps, a stranded user row exists with no
-      // redemption record. Recovery: an admin removes the stranded user
-      // via `npm run manage-users delete-user`. The invite is still
-      // redeemable until it expires. Acceptable for a home-server
-      // deployment; if this ever moves to multi-tenant, wrap both stores
-      // in a single SQLite database and use a transaction.
-      let user;
-      try {
-        user = await userStore.create({
-          username,
-          password,
-          slackId: peek.slackUserId ?? undefined,
-          role: peek.role,
-        });
-      } catch (err) {
-        recordAuthFailure('register', ip);
-        // Unified error message — don't reveal which usernames are taken
-        // (low-value enumeration vector even with invite gating).
-        logger.warn('Register validation failed', {
-          ip,
-          message: err instanceof Error ? err.message : String(err),
-        });
-        reject(400, 'Username or password did not pass validation.');
-        return;
-      }
-
-      // Atomic redeem — losses to a concurrent redeem return null. If we
-      // lose, roll back the user we just created so the invite owner
-      // isn't burned and the username isn't squatted.
-      const redeemed = inviteStore.redeemInvite(inviteCode, user.id);
-      if (!redeemed) {
-        userStore.deleteById(user.id);
-        recordAuthFailure('register', ip);
-        logger.warn('Lost invite redeem race; rolled back created user', { ip, userId: user.id });
-        reject(400, 'Invite code was just consumed. Please request a new one.');
-        return;
-      }
-
-      // The store-canonical username (post-Zod validation, lowercase
-      // canonicalization etc.) is the identity we mint sessions under.
-      // If for any reason it's null we refuse to create a session rather
-      // than silently fall back to the user-supplied form value.
-      if (!user.username) {
-        userStore.deleteById(user.id);
-        logger.error('User created without a canonical username — rolled back', { ip, userId: user.id });
-        reject(400, 'Could not create account.');
-        return;
-      }
-      const identityUserId = `web:${user.username}`;
-      const sessionStore = getSessionStore(dbPath, webConfig.sessionTtlHours);
-      sessionStore.deleteSessionsForUser(identityUserId);
-      const session = sessionStore.createSession(identityUserId, user.role === 'admin');
-      const maxAge = webConfig.sessionTtlHours * 60 * 60;
-      res.setHeader('Set-Cookie', `${SESSION_COOKIE}=${session.sessionId}; ${buildCookieOptions(webConfig, maxAge)}`);
-
-      logger.info('User registered via invite', { userId: identityUserId, role: user.role });
-      res.redirect(302, '/');
-    })().catch(next);
-  });
-
-  // Logout
-  app.post('/logout', (req: Request, res: Response) => {
-    const cookies = parseCookies(req.headers.cookie);
-    const sessionId = cookies[SESSION_COOKIE];
-    if (sessionId) {
-      const sessionStore = getSessionStore(dbPath, webConfig.sessionTtlHours);
-      sessionStore.deleteSession(sessionId);
-    }
-
-    // Clear cookie
-    res.setHeader('Set-Cookie', `${SESSION_COOKIE}=; ${buildCookieOptions(webConfig, 0)}`);
-    res.redirect(302, '/login');
-  });
-
-  // Mount conversation routes (auth applied globally at /c)
+  // Conversations (/c/*)
   app.use('/c', sessionAuthMiddleware(webConfig, dbPath), createConversationsRouter(claudeConfig, dbPath));
 
-  // ─── Admin routes (#277) ─────────────────────────────────────────────
-  // All routes under /admin require an active admin session. The chained
-  // middleware first does the standard session auth (401 if not logged
-  // in) and then enforces role=admin (403 otherwise). This way a logged-in
-  // non-admin sees the friendly 403 page rather than getting bounced to
-  // /login.
-  app.use('/admin', sessionAuthMiddleware(webConfig, dbPath), adminGuard);
+  // Admin (/admin/*) — sessionAuthMiddleware here; adminGuard is inside createAdminRouter
+  app.use('/admin', sessionAuthMiddleware(webConfig, dbPath), createAdminRouter(dbPath, webConfig));
 
-  app.get('/admin/users', (req: Request, res: Response) => {
-    try {
-      const userStore = getUserStore(dbPath);
-      const inviteStore = getInviteStore(dbPath);
-      const users = userStore.listAll();
-      const invites = inviteStore.listActive();
-      // Flash/error are deliberately stateless — they round-trip through
-      // the redirect URL. A bookmarked URL with an old `?error=...` will
-      // re-render the same message; that's acceptable for a home server
-      // and avoids a session-backed flash store.
-      const flash = typeof req.query.flash === 'string' ? req.query.flash : undefined;
-      const errMsg = typeof req.query.error === 'string' ? req.query.error : undefined;
-      res.type('html').send(
-        renderAdminUsers({
-          users,
-          invites,
-          baseUrl: webConfig.baseUrl,
-          flash,
-          error: errMsg,
-        }),
-      );
-    } catch (err) {
-      logger.error('Error rendering /admin/users', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      res.status(500).type('html').send(renderError('Failed to load admin page.'));
-    }
-  });
-
-  app.post('/admin/users', (req: Request, res: Response, next: NextFunction) => {
-    (async () => {
-      const body = req.body as Record<string, string>;
-      const slackId = (body.slack_id ?? '').trim();
-      const displayName = (body.display_name ?? '').trim() || undefined;
-      const role = body.role === 'admin' ? 'admin' : 'user';
-      if (!/^U[A-Z0-9]+$/.test(slackId)) {
-        res.redirect(302, '/admin/users?error=' + encodeURIComponent('Slack ID must look like U01ABC...'));
-        return;
-      }
-      const userStore = getUserStore(dbPath);
-      if (userStore.getBySlackId(slackId)) {
-        res.redirect(302, '/admin/users?error=' + encodeURIComponent('User already exists.'));
-        return;
-      }
-      await userStore.create({ slackId, role, displayName });
-      logger.info('Admin created user via web', {
-        actor: res.locals.userId as string,
-        slackId,
-        role,
-      });
-      res.redirect(302, '/admin/users?flash=' + encodeURIComponent(`Added ${slackId}.`));
-    })().catch(next);
-  });
-
-  app.post('/admin/users/:id/role', (req: Request, res: Response) => {
-    const id = parseInt(typeof req.params.id === 'string' ? req.params.id : '', 10);
-    const body = req.body as Record<string, string>;
-    const newRole = body.role === 'admin' ? 'admin' : 'user';
-    if (!Number.isInteger(id)) {
-      res.redirect(302, '/admin/users?error=Invalid+user+id');
-      return;
-    }
-    const userStore = getUserStore(dbPath);
-    const user = userStore.getById(id);
-    if (!user) {
-      res.redirect(302, '/admin/users?error=User+not+found');
-      return;
-    }
-    // Last-admin protection: count + update aren't atomic (same shape as
-    // #274's CLI). The window between count check and updateRole is a
-    // few SQLite operations; concurrent demotions of two different
-    // admins could each see count=2 and proceed, leaving zero. For a
-    // single-admin home-server context the probability is essentially
-    // zero. Once #310 (manage-users CLI) merges, swap to the atomic
-    // `demoteIfNotLastAdmin` it adds to UserStore.
-    if (user.role === 'admin' && newRole !== 'admin' && userStore.countByRole('admin') <= 1) {
-      res.redirect(302, '/admin/users?error=' + encodeURIComponent('Refusing to demote the last admin.'));
-      return;
-    }
-    userStore.updateRole(id, newRole);
-    logger.info('Admin changed user role', {
-      actor: res.locals.userId as string,
-      targetId: id,
-      newRole,
-    });
-    res.redirect(302, '/admin/users?flash=Role+updated');
-  });
-
-  app.post('/admin/users/:id/toggle-active', (req: Request, res: Response) => {
-    const id = parseInt(typeof req.params.id === 'string' ? req.params.id : '', 10);
-    if (!Number.isInteger(id)) {
-      res.redirect(302, '/admin/users?error=Invalid+user+id');
-      return;
-    }
-    const userStore = getUserStore(dbPath);
-    const user = userStore.getById(id);
-    if (!user) {
-      res.redirect(302, '/admin/users?error=User+not+found');
-      return;
-    }
-    if (user.isActive && user.role === 'admin' && userStore.countByRole('admin') <= 1) {
-      res.redirect(302, '/admin/users?error=' + encodeURIComponent('Refusing to deactivate the last admin.'));
-      return;
-    }
-    if (user.isActive) userStore.deactivate(id); else userStore.activate(id);
-    logger.info('Admin toggled user active', {
-      actor: res.locals.userId as string,
-      targetId: id,
-      newState: !user.isActive,
-    });
-    res.redirect(302, '/admin/users?flash=' + encodeURIComponent(user.isActive ? 'User deactivated.' : 'User activated.'));
-  });
-
-  app.post('/admin/users/:id/reset-password', (req: Request, res: Response, next: NextFunction) => {
-    (async () => {
-      const id = parseInt(typeof req.params.id === 'string' ? req.params.id : '', 10);
-      const body = req.body as Record<string, unknown>;
-      const newPassword = typeof body.password === 'string' ? body.password : '';
-      if (!Number.isInteger(id)) {
-        res.redirect(302, '/admin/users?error=Invalid+user+id');
-        return;
-      }
-      if (newPassword.length < 8) {
-        res.redirect(302, '/admin/users?error=' + encodeURIComponent('Password must be at least 8 characters.'));
-        return;
-      }
-      const userStore = getUserStore(dbPath);
-      const user = userStore.getById(id);
-      if (!user) {
-        res.redirect(302, '/admin/users?error=User+not+found');
-        return;
-      }
-      await userStore.updatePassword(id, newPassword);
-      logger.info('Admin reset user password', {
-        actor: res.locals.userId as string,
-        targetId: id,
-      });
-      res.redirect(302, '/admin/users?flash=Password+updated.');
-    })().catch(next);
-  });
-
-  app.post('/admin/invites', (req: Request, res: Response) => {
-    const body = req.body as Record<string, string>;
-    const role = body.role === 'admin' ? 'admin' : 'user';
-    const ttlHoursRaw = parseInt(body.ttl_hours ?? '72', 10);
-    const ttlHours = Number.isInteger(ttlHoursRaw) && ttlHoursRaw > 0
-      ? Math.min(ttlHoursRaw, 24 * 365)
-      : 72;
-    const slackUserIdRaw = (body.slack_user_id ?? '').trim();
-    const slackUserId = slackUserIdRaw || undefined;
-    if (slackUserId && !/^U[A-Z0-9]+$/.test(slackUserId)) {
-      res.redirect(302, '/admin/users?error=' + encodeURIComponent('Pre-link Slack ID must look like U01ABC...'));
-      return;
-    }
-
-    // Resolve the requesting admin's user-row id for invite_codes.created_by.
-    //
-    // Three session shapes possible:
-    //   - 'admin'         → static emergency-token session. No user row
-    //                       exists for this identity (and the route should
-    //                       still work for emergency access). Use 0 as a
-    //                       sentinel — invite_codes.created_by has no
-    //                       FK constraint, so 0 is a valid "system" marker.
-    //   - 'web:<user>'    → look up by username.
-    //   - 'U...'          → look up by Slack ID.
-    const userStore = getUserStore(dbPath);
-    const sessionUserId = res.locals.userId as string;
-    let createdByUserId: number;
-    if (sessionUserId === 'admin') {
-      createdByUserId = 0; // sentinel: static emergency-token issuer
-    } else {
-      const requester = sessionUserId.startsWith('web:')
-        ? userStore.getByUsername(sessionUserId.slice(4))
-        : userStore.getBySlackId(sessionUserId);
-      if (!requester) {
-        res.redirect(302, '/admin/users?error=' + encodeURIComponent(
-          'Your account is not in the users table. Run `npm run manage-users create-user` first.',
-        ));
-        return;
-      }
-      createdByUserId = requester.id;
-    }
-
-    const inviteStore = getInviteStore(dbPath);
-    inviteStore.createInvite(createdByUserId, { role, ttlHours, slackUserId });
-    logger.info('Admin created invite via web', { actor: sessionUserId, role, ttlHours });
-    res.redirect(302, '/admin/users?flash=Invite+created.');
-  });
-
-  app.post('/admin/invites/:code/delete', (req: Request, res: Response) => {
-    const code = typeof req.params.code === 'string' ? req.params.code : '';
-    if (!/^[0-9a-f]{32}$/.test(code)) {
-      res.redirect(302, '/admin/users?error=Invalid+code');
-      return;
-    }
-    const inviteStore = getInviteStore(dbPath);
-    inviteStore.deleteInvite(code);
-    logger.info('Admin deleted invite', { actor: res.locals.userId as string, code });
-    res.redirect(302, '/admin/users?flash=Invite+deleted.');
-  });
-
-
-  // Mount API + notifications routes
+  // API + notifications
   app.use('/', createApiRouter(claudeConfig, webConfig, dbPath));
 
-  // ─── Plugin Web Routes ────────────────────────────────────────────────
-  // Mount plugin routes with per-plugin auth: public plugins use optional auth,
-  // private plugins require session auth (401 on failure)
+  // Plugin routes — per-plugin auth: public plugins use optional auth, private require session
   const pluginAuth = (req: Request, res: Response, next: NextFunction): void => {
     const match = /^\/([^/]+)/.exec(req.path);
     const pluginName = match?.[1];
@@ -587,38 +119,10 @@ export async function startWebServer(webConfig: WebConfig): Promise<void> {
   };
   app.use('/p', pluginAuth, getPluginExpressRouter());
 
-  // Dashboard home: GET / (optional auth — public with reduced view)
-  app.get('/', optionalAuthMiddleware(webConfig, dbPath), async (_req: Request, res: Response) => {
-    try {
-      const isAuthenticated = !!res.locals.userId;
-      const userId = (res.locals.userId as string) || 'anonymous';
-      const health = await getServerHealth();
+  // Dashboard, static, and auth routes (mounted last so plugin routes take precedence at /p)
+  app.use('/', createDashboardRouter(claudeConfig, webConfig, dbPath));
 
-      // Only load private data for authenticated users — and scope it
-      // to the user's identities so non-admins only see their own data.
-      const store = getConversationStore(claudeConfig.dbPath, claudeConfig.conversationTtlHours);
-      const filterIds = isAuthenticated ? getUserFilterIds(res, dbPath) : undefined;
-      const stats = isAuthenticated ? store.getSessionStats(24, filterIds) : { totalSessions: 0, activeSessions: 0, totalMessages: 0, totalToolCalls: 0, avgToolDurationMs: null, toolFailureRate: 0, topTools: [] as { name: string; count: number; avgDurationMs: number | null }[] };
-      const recent = isAuthenticated ? store.listRecentSessions(5, 0, filterIds) : [];
-      if (isAuthenticated) attachTags(recent, store);
-      const favorites = isAuthenticated ? store.listFavoriteSessions(3, 0, filterIds) : [];
-      const favCount = isAuthenticated ? store.countFavoriteSessions(filterIds) : 0;
-      const allTags = isAuthenticated ? store.listAllTags(filterIds) : [];
-      const widgets = getPluginWidgets(!isAuthenticated);
-      const notifStore = getNotificationStore(claudeConfig.dbPath);
-      const unreadCount = isAuthenticated ? notifStore.countUnread() : 0;
-      const linksStore = getQuickLinksStore(claudeConfig.dbPath);
-      const userLinks = isAuthenticated ? linksStore.getLinks(userId) : [];
-
-      const html = renderDashboard(stats, recent, favorites, favCount, allTags, userId, widgets, unreadCount, userLinks, health, isAuthenticated);
-      res.type('html').send(html);
-    } catch (err) {
-      logger.error('Error serving dashboard', { error: err instanceof Error ? err.message : String(err) });
-      res.status(500).send(renderError('Failed to load dashboard.'));
-    }
-  });
-
-  // 404 for everything else
+  // 404 catch-all
   app.use((_req: Request, res: Response) => {
     res.status(404).send(render404());
   });
@@ -693,26 +197,4 @@ export async function stopWebServer(): Promise<void> {
       }
     });
   });
-}
-
-/**
- * Generate a web URL for a conversation
- *
- * Creates an HMAC-signed, time-limited link token for the given user.
- *
- * @param threadTs - Thread timestamp
- * @param channelId - Channel ID
- * @param webConfig - Web configuration
- * @param userId - Slack user ID to encode in the token
- * @returns Full URL with HMAC authentication token
- */
-export function getConversationUrl(
-  threadTs: string,
-  channelId: string,
-  webConfig: WebConfig,
-  userId?: string,
-): string {
-  const baseUrl = webConfig.baseUrl ?? `http://localhost:${String(webConfig.port)}`;
-  const token = createLinkToken(userId ?? 'system', webConfig.authToken, webConfig.linkTokenTtlMinutes);
-  return `${baseUrl}/c/${threadTs}/${channelId}?token=${encodeURIComponent(token)}`;
 }

--- a/tests/web/routes/admin.test.ts
+++ b/tests/web/routes/admin.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import type { Server } from 'http';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../src/config/index.js', () => ({
+  config: {
+    claude: { dbPath: ':memory:', conversationTtlHours: 24 },
+    web: { enabled: true, port: 0, baseUrl: 'http://localhost', authToken: 'test-token-min16', linkTokenTtlMinutes: 15, sessionTtlHours: 72 },
+  },
+}));
+
+const mockUserStore = {
+  create: vi.fn(),
+  getById: vi.fn(),
+  getByUsername: vi.fn(),
+  getBySlackId: vi.fn(),
+  listAll: vi.fn(() => []),
+  countByRole: vi.fn(() => 2),
+  updateRole: vi.fn(),
+  deactivate: vi.fn(),
+  activate: vi.fn(),
+  updatePassword: vi.fn(),
+  deleteById: vi.fn(),
+  resolveIdentities: vi.fn(),
+};
+
+vi.mock('../../../src/services/user-store.js', () => ({
+  getUserStore: vi.fn(() => mockUserStore),
+}));
+
+const mockInviteStore = {
+  createInvite: vi.fn(),
+  getInvite: vi.fn(),
+  redeemInvite: vi.fn(),
+  listActive: vi.fn(() => []),
+  deleteInvite: vi.fn(),
+};
+
+vi.mock('../../../src/services/invite-store.js', () => ({
+  getInviteStore: vi.fn(() => mockInviteStore),
+}));
+
+vi.mock('../../../src/web/templates/index.js', () => ({
+  renderAdminUsers: vi.fn(() => '<html>admin users</html>'),
+  renderError: vi.fn(() => '<html>error</html>'),
+  render403: vi.fn(() => '<html>403 forbidden</html>'),
+}));
+
+import { createAdminRouter } from '../../../src/web/routes/admin.js';
+import type { WebConfig } from '../../../src/config/schema.js';
+
+const webConfig: WebConfig = {
+  enabled: true,
+  port: 0,
+  baseUrl: 'http://localhost',
+  authToken: 'test-token-min16',
+  linkTokenTtlMinutes: 15,
+  sessionTtlHours: 72,
+};
+const dbPath = ':memory:';
+
+function makeApp(isAdmin: boolean): express.Express {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
+  app.use((_req, res, next) => {
+    res.locals.userId = 'U123';
+    res.locals.isAdmin = isAdmin;
+    next();
+  });
+  app.use('/', createAdminRouter(dbPath, webConfig));
+  return app;
+}
+
+let adminServer: Server;
+let nonAdminServer: Server;
+let adminBaseUrl: string;
+let nonAdminBaseUrl: string;
+
+beforeAll(async () => {
+  const adminApp = makeApp(true);
+  const nonAdminApp = makeApp(false);
+
+  await new Promise<void>((resolve) => {
+    adminServer = adminApp.listen(0, '127.0.0.1', resolve);
+  });
+  await new Promise<void>((resolve) => {
+    nonAdminServer = nonAdminApp.listen(0, '127.0.0.1', resolve);
+  });
+
+  const adminAddr = adminServer.address() as { port: number };
+  const nonAdminAddr = nonAdminServer.address() as { port: number };
+  adminBaseUrl = `http://127.0.0.1:${adminAddr.port}`;
+  nonAdminBaseUrl = `http://127.0.0.1:${nonAdminAddr.port}`;
+});
+
+afterAll(async () => {
+  await Promise.all([
+    new Promise<void>((resolve, reject) => adminServer.close((err) => (err ? reject(err) : resolve()))),
+    new Promise<void>((resolve, reject) => nonAdminServer.close((err) => (err ? reject(err) : resolve()))),
+  ]);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUserStore.listAll.mockReturnValue([]);
+  mockInviteStore.listActive.mockReturnValue([]);
+});
+
+describe('GET /users', () => {
+  it('returns 200 with admin page HTML for an admin session', async () => {
+    const res = await fetch(`${adminBaseUrl}/users`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('admin users');
+  });
+
+  it('returns 403 for a non-admin session', async () => {
+    const res = await fetch(`${nonAdminBaseUrl}/users`);
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the \`server.ts\` split started in #39. Extracts the remaining route handlers into two new focused modules, reducing \`server.ts\` from 718 lines to 200 lines (the thin orchestrator it was always meant to be). Zero behavior change — same URLs, same response shapes, same exports.

## Changes

- **\`src/web/routes/admin.ts\`** (new) — all \`/admin/*\` handlers. \`adminGuard\` is applied internally via \`router.use(adminGuard)\` so callers only need to wire \`sessionAuthMiddleware\`. Documents the known last-admin non-atomicity race and the planned \`demoteIfNotLastAdmin\` fix (#310).
- **\`src/web/routes/dashboard.ts\`** (new) — \`GET /health\`, \`GET /manifest.json\`, \`GET /static/styles.css\`, auth routes (\`/login\`, \`/register\`, \`/logout\`), and \`GET /\` dashboard. \`getConversationUrl\` is exported from here and re-exported from \`server.ts\` for backward compatibility.
- **\`src/web/server.ts\`** — now a 200-line thin aggregator: middleware setup, router mounts, error handler, cleanup timer, listen.
- **\`tests/web/routes/admin.test.ts\`** (new) — covers the two acceptance-criteria cases: \`GET /admin/users\` → 200 (admin session) / 403 (non-admin session).

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 3382/3382 passed (135 test files)
- [x] \`npm run test:e2e\` — 44/44 Playwright tests pass
- [x] Full \`npm run ci\` — green
- [x] \`src/web/server.ts\` is 200 lines (≤ 250 target)
- [x] All \`/admin/*\` and auth routes respond identically (covered by existing \`admin-users.test.ts\`, \`auth-journey.test.ts\`, \`register.test.ts\`)
- [x] \`getConversationUrl\` re-exported from \`server.ts\` path unchanged

## Notes

Pre-existing \`qs\` moderate-severity advisory (in \`typed-rest-client\`) is not introduced by this PR.

Closes #38