### PR TITLE
fix(prepare): skip git submodule update outside a git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "screenshots": "tsx scripts/take-screenshots.ts",
     "manage-users": "tsx src/cli/manage-users.ts",
     "agentbox:build": "bash scripts/build-agentbox.sh",
-    "prepare": "git submodule update --init --recursive && npm run agentbox:build"
+    "prepare": "if git rev-parse --git-dir > /dev/null 2>&1; then git submodule update --init --recursive && npm run agentbox:build; fi"
   },
   "keywords": [
     "slack",


### PR DESCRIPTION
## Summary
- The `prepare` lifecycle script runs `git submodule update --init --recursive` on every `npm ci` / `npm install`
- This breaks in Docker build contexts and CI environments where there is no `.git` directory — `git submodule update` fails with _"fatal: not a git repository"_
- Fix: guard the whole script behind `git rev-parse --git-dir` so it silently skips when there is no git context

## Behaviour
| Context | Before | After |
|---|---|---|
| Developer machine (git repo) | ✅ runs normally | ✅ runs normally |
| Docker build (no `.git`) | ❌ fatal: not a git repository | ✅ no-op, exits 0 |
| CI / npm publish sandbox | ❌ fatal: not a git repository | ✅ no-op, exits 0 |

Failure semantics are preserved: if the submodule update or `agentbox:build` fails inside a real git repo, the script still exits non-zero.