### PR TITLE
feat(disk): show sizes and labels for attached storage in /stats and /disk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,11 @@ BACKUP_DIRS=
 # S3 bucket name for backup verification (optional)
 S3_BACKUP_BUCKET=
 
+# Friendly labels for attached storage mount points shown in /stats and /disk
+# Format: comma-separated mount:Label pairs
+# Example: DISK_LABELS=/mnt/storage:Storage Drive,/mnt/backupDrive:Backup Drive
+DISK_LABELS=
+
 # =============================================================================
 # Logging
 # =============================================================================

--- a/src/commands/resources.ts
+++ b/src/commands/resources.ts
@@ -158,7 +158,7 @@ export function registerDiskCommand(app: App): void {
       for (const mount of mounts) {
         const status = getUsageStatus(mount.percentUsed);
         const label = diskLabels[mount.mountPoint];
-        const displayName = label ? `${label} (${mount.mountPoint})` : mount.mountPoint;
+        const displayName = label ? `${label} \`${mount.mountPoint}\`` : mount.mountPoint;
         blocks.push(
           sectionWithFields([
             `*${displayName}*\n${statusEmoji(status)} ${String(mount.percentUsed)}% used`,

--- a/src/commands/resources.ts
+++ b/src/commands/resources.ts
@@ -1,5 +1,6 @@
 import type { App } from '@slack/bolt';
 import type { KnownBlock } from '@slack/types';
+import { config } from '../config/index.js';
 import { getSystemResources, getDiskUsage } from '../executors/system.js';
 import {
   header,
@@ -152,11 +153,15 @@ export function registerDiskCommand(app: App): void {
         divider(),
       ];
 
+      const diskLabels = config.server.diskLabels;
+
       for (const mount of mounts) {
         const status = getUsageStatus(mount.percentUsed);
+        const label = diskLabels[mount.mountPoint];
+        const displayName = label ? `${label} (${mount.mountPoint})` : mount.mountPoint;
         blocks.push(
           sectionWithFields([
-            `*${mount.mountPoint}*\n${statusEmoji(status)} ${String(mount.percentUsed)}% used`,
+            `*${displayName}*\n${statusEmoji(status)} ${String(mount.percentUsed)}% used`,
             `*Size:* ${mount.size}\n*Used:* ${mount.used}\n*Free:* ${mount.available}`,
           ])
         );

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -101,13 +101,28 @@ export function registerStatsCommand(app: App): void {
           ),
         );
 
-        // Disk usage
+        // Disk usage — split system mounts from attached storage (/mnt/* or labeled mounts)
         if (health.disks.length > 0) {
-          const diskLines = health.disks.map((d) => {
+          const diskLabels = config.server.diskLabels;
+          const isAttached = (mountPoint: string) =>
+            mountPoint in diskLabels || mountPoint.startsWith('/mnt/');
+
+          const formatDiskLine = (d: { mountPoint: string; percentUsed: number; used: string; size: string }) => {
             const diskStatus = d.percentUsed >= 90 ? 'error' : d.percentUsed >= 75 ? 'warn' : 'ok';
-            return `${statusEmoji(diskStatus)} \`${d.mountPoint}\` ${progressBar(d.percentUsed, 100)} ${String(Math.round(d.percentUsed))}%`;
-          });
-          blocks.push(section(`*Disk Usage*\n${diskLines.join('\n')}`));
+            const label = diskLabels[d.mountPoint];
+            const displayName = label ? `${label} \`${d.mountPoint}\`` : `\`${d.mountPoint}\``;
+            return `${statusEmoji(diskStatus)} ${displayName} ${progressBar(d.percentUsed, 100)} ${String(Math.round(d.percentUsed))}%  ${d.used} / ${d.size}`;
+          };
+
+          const systemDisks = health.disks.filter((d) => !isAttached(d.mountPoint));
+          const attachedDisks = health.disks.filter((d) => isAttached(d.mountPoint));
+
+          if (systemDisks.length > 0 && attachedDisks.length > 0) {
+            blocks.push(section(`*System Disk*\n${systemDisks.map(formatDiskLine).join('\n')}`));
+            blocks.push(section(`*Attached Storage*\n${attachedDisks.map(formatDiskLine).join('\n')}`));
+          } else {
+            blocks.push(section(`*Disk Usage*\n${health.disks.map(formatDiskLine).join('\n')}`));
+          }
         }
       } else {
         blocks.push(section('_Could not fetch system health._'));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -64,6 +64,26 @@ export function parseContextOptions(value: string | undefined): { alias: string;
 }
 
 /**
+ * Parse disk labels from comma-separated mount:label pairs
+ * Example: "/mnt/storage:Storage Drive,/mnt/backupDrive:Backup Drive"
+ * Malformed entries (missing colon, empty mount, empty label) are silently skipped.
+ */
+export function parseDiskLabels(value: string | undefined): Record<string, string> {
+  if (!value) return {};
+  const labels: Record<string, string> = {};
+  for (const pair of value.split(',').map((s) => s.trim()).filter((s) => s.length > 0)) {
+    const colonIndex = pair.indexOf(':');
+    if (colonIndex === -1) continue;
+    const mount = pair.slice(0, colonIndex).trim();
+    const label = pair.slice(colonIndex + 1).trim();
+    if (mount && label) {
+      labels[mount] = label;
+    }
+  }
+  return labels;
+}
+
+/**
  * Parse GitHub repos from comma-separated owner/repo:description pairs
  * Example: "swamp-dev/ansible:Home server playbooks,swamp-dev/bot:Slack bot"
  */
@@ -124,6 +144,7 @@ function loadConfig(): Config {
       maxLogLines: parseIntWithDefault(process.env.MAX_LOG_LINES, 50),
       backupDirs: parseCommaSeparated(process.env.BACKUP_DIRS),
       s3BackupBucket: process.env.S3_BACKUP_BUCKET ?? undefined,
+      diskLabels: parseDiskLabels(process.env.DISK_LABELS),
     },
     logging: {
       level: (process.env.LOG_LEVEL ?? 'info') as 'debug' | 'info' | 'warn' | 'error',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -150,6 +150,8 @@ export const ConfigSchema = z.object({
     backupDirs: z.array(SafeBackupDirSchema).default([]),
     /** S3 bucket for backup verification */
     s3BackupBucket: z.string().optional(),
+    /** Friendly labels for specific mount points, e.g. { '/mnt/storage': 'Storage Drive' } */
+    diskLabels: z.record(z.string(), z.string()).default({}),
   }),
 
   logging: z.object({

--- a/tests/commands/resources.test.ts
+++ b/tests/commands/resources.test.ts
@@ -16,6 +16,14 @@ vi.mock('../../src/utils/logger.js', () => ({
   },
 }));
 
+vi.mock('../../src/config/index.js', () => ({
+  config: {
+    server: {
+      diskLabels: {},
+    },
+  },
+}));
+
 // Import after mocks
 const { registerResourcesCommand, registerDiskCommand } = await import(
   '../../src/commands/resources.js'

--- a/tests/commands/stats.test.ts
+++ b/tests/commands/stats.test.ts
@@ -7,6 +7,9 @@ vi.mock('../../src/config/index.js', () => ({
       dbPath: ':memory:',
       conversationTtlHours: 24,
     },
+    server: {
+      diskLabels: {},
+    },
   },
 }));
 
@@ -115,5 +118,43 @@ describe('stats command', () => {
     await handler({ ack: vi.fn(), respond: vi.fn() });
 
     expect(mockCountUniqueUsers).toHaveBeenCalledWith(24);
+  });
+
+  it('should show disk sizes alongside percentage', async () => {
+    const app = { command: vi.fn() };
+    registerStatsCommand(app as never);
+
+    const ack = vi.fn();
+    const respond = vi.fn();
+    const handler = app.command.mock.calls[0][1];
+    await handler({ ack, respond });
+
+    const blocks = respond.mock.calls[0][0].blocks;
+    const allText = blocks
+      .filter((b: Record<string, unknown>) => b.type === 'section')
+      .map((b: Record<string, unknown>) => (b.text as Record<string, string>).text)
+      .join('\n');
+
+    // Disk size info should appear in format "used / size"
+    expect(allText).toContain('2T / 8T');   // /mnt/storage mock values
+    expect(allText).toContain('200G / 500G'); // / mock values
+  });
+
+  it('should split system and attached disks into separate sections when both present', async () => {
+    const app = { command: vi.fn() };
+    registerStatsCommand(app as never);
+
+    const ack = vi.fn();
+    const respond = vi.fn();
+    const handler = app.command.mock.calls[0][1];
+    await handler({ ack, respond });
+
+    const blocks = respond.mock.calls[0][0].blocks;
+    const sectionTexts = blocks
+      .filter((b: Record<string, unknown>) => b.type === 'section')
+      .map((b: Record<string, unknown>) => (b.text as Record<string, string>).text);
+
+    expect(sectionTexts.some((t: string) => t.includes('System Disk'))).toBe(true);
+    expect(sectionTexts.some((t: string) => t.includes('Attached Storage'))).toBe(true);
   });
 });

--- a/tests/config/index.test.ts
+++ b/tests/config/index.test.ts
@@ -12,7 +12,7 @@ vi.stubEnv('SLACK_APP_TOKEN', 'xapp-test-token');
 vi.stubEnv('AUTHORIZED_USER_IDS', 'U12345678');
 
 // Now we can safely import the parsing functions
-const { parseCommaSeparated, parseIntWithDefault, parseContextOptions, parseGithubRepos } = await import(
+const { parseCommaSeparated, parseIntWithDefault, parseContextOptions, parseGithubRepos, parseDiskLabels } = await import(
   '../../src/config/index.js'
 );
 
@@ -208,6 +208,62 @@ describe('config parsing functions', () => {
         { repo: 'org/repo-a', description: 'A' },
         { repo: 'org/repo-b', description: 'B' },
       ]);
+    });
+  });
+
+  describe('parseDiskLabels', () => {
+    it('should parse mount:label pairs', () => {
+      const result = parseDiskLabels('/mnt/storage:Storage Drive');
+      expect(result).toEqual({ '/mnt/storage': 'Storage Drive' });
+    });
+
+    it('should parse multiple pairs', () => {
+      const result = parseDiskLabels('/mnt/storage:Storage Drive,/mnt/backupDrive:Backup Drive');
+      expect(result).toEqual({
+        '/mnt/storage': 'Storage Drive',
+        '/mnt/backupDrive': 'Backup Drive',
+      });
+    });
+
+    it('should handle empty string', () => {
+      expect(parseDiskLabels('')).toEqual({});
+    });
+
+    it('should handle undefined', () => {
+      expect(parseDiskLabels(undefined)).toEqual({});
+    });
+
+    it('should trim whitespace around mount and label', () => {
+      const result = parseDiskLabels('  /mnt/storage : Storage Drive  ');
+      expect(result).toEqual({ '/mnt/storage': 'Storage Drive' });
+    });
+
+    it('should skip malformed entries with no colon', () => {
+      const result = parseDiskLabels('/mnt/storage,/mnt/backupDrive:Backup Drive');
+      expect(result).toEqual({ '/mnt/backupDrive': 'Backup Drive' });
+    });
+
+    it('should skip entries with empty mount path', () => {
+      const result = parseDiskLabels(':Storage Drive,/mnt/backupDrive:Backup Drive');
+      expect(result).toEqual({ '/mnt/backupDrive': 'Backup Drive' });
+    });
+
+    it('should skip entries with empty label', () => {
+      const result = parseDiskLabels('/mnt/storage:,/mnt/backupDrive:Backup Drive');
+      expect(result).toEqual({ '/mnt/backupDrive': 'Backup Drive' });
+    });
+
+    it('should handle labels containing colons', () => {
+      const result = parseDiskLabels('/mnt/storage:Storage: Main Drive');
+      expect(result).toEqual({ '/mnt/storage': 'Storage: Main Drive' });
+    });
+
+    it('should filter empty entries from trailing commas', () => {
+      const result = parseDiskLabels('/mnt/storage:Storage Drive,,/mnt/backupDrive:Backup Drive,');
+      expect(result).toEqual({
+        '/mnt/storage': 'Storage Drive',
+        '/mnt/backupDrive': 'Backup Drive',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- `/stats` now splits disks into **System Disk** and **Attached Storage** sections when both are present (attached = mounts under `/mnt/` or labeled mounts)
- All disk lines in `/stats` now show `used / size` alongside the progress bar (e.g. `2T / 8T`), so you can see the raw space available, not just a percentage
- `/disk` applies friendly labels to mount section headers when configured via `DISK_LABELS`
- New `DISK_LABELS` env var: `DISK_LABELS=/mnt/storage:Storage Drive,/mnt/backupDrive:Backup Drive`

## Changes

- `src/config/index.ts` — `parseDiskLabels()` function; parses `mount:label` pairs, silently skips malformed entries
- `src/config/schema.ts` — `server.diskLabels: Record<string, string>` Zod field
- `src/commands/stats.ts` — system/attached split, sizes shown, labels applied
- `src/commands/resources.ts` — labels applied to `/disk` command
- `.env.example` — documents `DISK_LABELS`
- Tests added for `parseDiskLabels`, disk display sections, and size display

## Testing

- [x] All 3394 tests pass locally
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Code review run; format inconsistency (parens vs backtick) addressed before merging
- [ ] Manual: set `DISK_LABELS=/mnt/storage:Storage Drive,/mnt/backupDrive:Backup Drive` in `.env`, run `/stats` in Slack and verify the split sections appear with labels and sizes

Closes #N/A